### PR TITLE
fix: 优先复用本地缓存的 biliup，避免每次运行都强制检查 GitHub Release

### DIFF
--- a/uploader/bilibili_uploader/runtime.py
+++ b/uploader/bilibili_uploader/runtime.py
@@ -153,10 +153,19 @@ def download_biliup_asset(release: dict, destination: Path) -> Path:
 def ensure_biliup_binary(force_check: bool = True) -> Path:
     binary_path = build_biliup_runtime_path()
     local_version = read_local_biliup_version()
-    if binary_path.exists() and local_version and not force_check:
+
+    # 默认优先复用本地已存在的 biliup，避免每次执行都去请求 GitHub latest release。
+    if binary_path.exists() and not force_check:
         return binary_path
 
-    release = fetch_latest_release()
+    try:
+        release = fetch_latest_release()
+    except Exception:
+        # 如果本地已经有可执行的 biliup，就在 GitHub 限流/网络失败时直接复用本地版本。
+        if binary_path.exists():
+            return binary_path
+        raise
+
     latest_version = release["tag_name"]
     if binary_path.exists() and local_version == latest_version:
         return binary_path
@@ -167,7 +176,7 @@ def ensure_biliup_binary(force_check: bool = True) -> Path:
 
 
 def run_biliup_command(arguments: list[str], interactive: bool = False) -> subprocess.CompletedProcess[str]:
-    binary_path = ensure_biliup_binary(force_check=True)
+    binary_path = ensure_biliup_binary(force_check=False)
     command = [str(binary_path), *arguments]
     if interactive:
         return subprocess.run(command, check=False)


### PR DESCRIPTION
## 变更说明

本次修复调整了 Bilibili 运行时对 biliup 的处理逻辑：

- 优先复用本地已经缓存的 biliup
- 不再在每次执行时都强制请求 GitHub latest release
- 当 GitHub 请求失败（例如 rate limit / 网络异常）时，如果本地已经存在可用的 biliup，则直接继续使用本地版本

## 背景问题

之前的实现中，Bilibili 上传在每次执行时都会强制访问 GitHub release API。
即使本地已经有可用的 biliup，仍然依赖外部网络请求。

这会导致：
- 无谓增加外部依赖
- 在 GitHub rate limit 场景下，发布流程直接失败

## 修复思路

改成更稳妥的运行方式：

- 如果本地已经存在 biliup，默认直接复用
- 只有在本地缺失时，才需要联网准备
- 如果联网检查失败，但本地已有可执行版本，则继续使用本地版本

## 预期收益

- 降低 Bilibili 上传对 GitHub API 的强依赖
- 避免因为 GitHub rate limit 导致上传失败
- 提升已有本地运行时场景下的稳定性