### PR TITLE
feat: 封面横竖屏双传 + aweme_id从create_v2捕获

### DIFF
--- a/sauModify.md
+++ b/sauModify.md
@@ -1,0 +1,57 @@
+# SAU 源码修改记录
+
+## 修改文件
+
+`uploader/douyin_uploader/main.py`
+
+## 修改内容
+
+### 视频发布成功后打印 aweme_id
+
+**位置**: 第 581 行，`douyin_logger.success(_msg("🥳", "视频发布成功，小人开心收工"))` 之后
+
+**目的**: SAU 的 `sau` 命令行进程成功时 stdout 不输出视频 ID，导致 douyin-api 无法获取抖音作品链接。本修改从发布成功后的页面 URL 中提取 `aweme_id` 并打印，供外部程序（douyin-api server.js）解析。
+
+**代码变更**:
+
+```python
+# 修改前
+douyin_logger.success(_msg("🥳", "视频发布成功，小人开心收工"))
+
+# 修改后
+douyin_logger.success(_msg("🥳", "视频发布成功，小人开心收工"))
+# 提取并打印 aweme_id（供外部程序解析）
+url = page.url
+import re
+m = re.search(r'[?&]aweme_id=(\d+)', url)
+if m:
+    print(f"SAU_AWEME_ID:{m.group(1)}")
+```
+
+**输出格式**: `SAU_AWEME_ID:7523456789012345678`
+
+**说明**:
+- 发布成功后页面跳转到 `https://creator.douyin.com/creator-micro/content/manage?aweme_id={数字}&...`，URL 参数中包含 `aweme_id`
+- 用正则 `[?&]aweme_id=(\d+)` 从 `page.url` 中提取
+- 打印到 stdout，后被 douyin-api server.js 的 `proc.stdout.on('data')` 捕获
+
+## douyin-api 侧对应修改
+
+**文件**: `server.js`（`/admin/sau/submit` 路由，close 回调中）
+
+**变更**: aweme_id 解析顺序增加 `SAU_AWEME_ID:` 前缀匹配
+
+```javascript
+// 1. 先尝试 SAU_AWEME_ID: 前缀
+const sauMatch = stdout.match(/SAU_AWEME_ID:(\d+)/);
+if (sauMatch) {
+  awemeId = sauMatch[1];
+} else {
+  // 2. 再尝试 JSON 格式
+  // 3. 最后尝试正则匹配
+}
+```
+
+## 日期
+
+2026-04-16

--- a/sau_cli.py
+++ b/sau_cli.py
@@ -170,7 +170,7 @@ def parse_schedule(raw_schedule: str | None) -> datetime | int:
 
 async def login_douyin_account(account_name: str, headless: bool = True) -> dict:
     account_file = resolve_account_file("douyin", account_name)
-    return await douyin_setup(str(account_file), handle=True, return_detail=True, headless=headless)
+    return await douyin_setup(str(account_file), handle=True, return_detail=True, headless=headless, keep_open=True)
 
 
 async def check_douyin_account(account_name: str) -> bool:
@@ -249,6 +249,7 @@ async def upload_video(request: DouyinVideoUploadRequest) -> Path:
         request.publish_date,
         str(account_file),
         desc=request.description,
+        thumbnail_landscape_path=str(request.thumbnail_file) if request.thumbnail_file else None,
         thumbnail_portrait_path=str(request.thumbnail_file) if request.thumbnail_file else None,
         productLink=request.product_link,
         productTitle=request.product_title,

--- a/uploader/douyin_uploader/main.py
+++ b/uploader/douyin_uploader/main.py
@@ -28,6 +28,25 @@ def _msg(emoji: str, text: str) -> str:
     return f"{emoji} {text}"
 
 
+async def douyin_open_browser(account_file, headless: bool = False):
+    """打开浏览器并加载已有 cookie，保持窗口直到用户手动关闭。"""
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch(headless=headless, channel="chrome")
+        context = await browser.new_context(storage_state=account_file if os.path.exists(account_file) else None)
+        context = await set_init_script(context)
+        page = await context.new_page()
+        await page.goto("https://creator.douyin.com/creator-micro/home")
+        douyin_logger.info(_msg("🪟", "浏览器已打开，请手动操作，关闭窗口后自动退出"))
+        try:
+            await context.wait_for_event("close")
+        except Exception:
+            pass
+        try:
+            await context.storage_state(path=account_file)
+        except Exception:
+            pass
+
+
 async def _emit_qrcode_callback(qrcode_callback, payload: dict):
     if not qrcode_callback:
         return
@@ -69,14 +88,20 @@ async def cookie_auth(account_file):
             await browser.close()
 
 
-async def douyin_setup(account_file, handle=False, return_detail=False, qrcode_callback=None, headless: bool = LOCAL_CHROME_HEADLESS):
+async def douyin_setup(account_file, handle=False, return_detail=False, qrcode_callback=None, headless: bool = LOCAL_CHROME_HEADLESS, keep_open: bool = False):
     if not os.path.exists(account_file) or not await cookie_auth(account_file):
         if not handle:
             result = _build_login_result(False, "cookie_invalid", "cookie文件不存在或已失效", account_file)
             return result if return_detail else False
         douyin_logger.info(_msg("🥹", "cookie 失效了，准备打开浏览器重新登录"))
-        result = await douyin_cookie_gen(account_file, qrcode_callback=qrcode_callback, headless=headless)
+        result = await douyin_cookie_gen(account_file, qrcode_callback=qrcode_callback, headless=headless, keep_open=keep_open)
         return result if return_detail else result["success"]
+
+    if keep_open:
+        douyin_logger.info(_msg("🪟", "cookie 有效，打开浏览器供手动操作"))
+        await douyin_open_browser(account_file, headless=headless)
+        result = _build_login_result(True, "cookie_valid", "已打开浏览器", account_file)
+        return result if return_detail else True
 
     result = _build_login_result(True, "cookie_valid", "cookie有效", account_file)
     return result if return_detail else True
@@ -174,6 +199,7 @@ async def douyin_cookie_gen(
     poll_interval: int = 3,
     max_checks: int = 100,
     headless: bool = LOCAL_CHROME_HEADLESS,
+    keep_open: bool = False,
 ):
     async with async_playwright() as playwright:
         browser = await playwright.chromium.launch(headless=headless, channel="chrome")
@@ -207,6 +233,9 @@ async def douyin_cookie_gen(
                         qrcode_info,
                         page.url,
                     )
+                elif keep_open:
+                    douyin_logger.info(_msg("🪟", "登录成功，浏览器保持打开，请手动关闭窗口后继续"))
+                    await context.wait_for_event("close")
         except Exception as exc:
             result = _build_login_result(False, "failed", str(exc), account_file, current_url=page.url if "page" in locals() else "")
         finally:
@@ -416,7 +445,9 @@ class DouYinVideo(DouYinBaseUploader):
         douyin_logger.warning(_msg("😵", "视频上传摔了一跤，小人马上重新上传"))
         await page.locator('div.progress-div [class^="upload-btn-input"]').set_input_files(self.file_path)
 
-    async def handle_auto_video_cover(self, page):
+    async def handle_auto_video_cover(self, page: Page):
+        if not self.thumbnail_landscape_path and not self.thumbnail_portrait_path:
+            return  # 没有手动设置封面，不干预自动选择
         if await page.get_by_text("请设置封面后再发布").first.is_visible():
             douyin_logger.info(_msg("🧍", "发布前还得先把封面弄好"))
             recommend_cover = page.locator('[class^="recommendCover-"]').first
@@ -438,6 +469,7 @@ class DouYinVideo(DouYinBaseUploader):
         return False
 
     async def set_thumbnail(self, page: Page):
+        douyin_logger.info(_msg("🔍", f"封面路径检查: landscape={self.thumbnail_landscape_path}, portrait={self.thumbnail_portrait_path}"))
         if not self.thumbnail_landscape_path and not self.thumbnail_portrait_path:
             return
 
@@ -450,18 +482,19 @@ class DouYinVideo(DouYinBaseUploader):
         upload_input = cover_locator.locator("div[class^='semi-upload upload'] >> input.semi-upload-hidden-input")
 
         if self.thumbnail_landscape_path:
-            await page.wait_for_timeout(1000)
+            await page.wait_for_timeout(1500)
             await upload_input.set_input_files(self.thumbnail_landscape_path)
-            await page.wait_for_timeout(2000)
+            await page.wait_for_timeout(3000)
             douyin_logger.info(_msg("🖼️", "横版封面上传完成"))
 
         if self.thumbnail_portrait_path:
             await cover_locator.locator("div[class*='steps'] div").nth(1).click()
-            await page.wait_for_timeout(1000)
+            await page.wait_for_timeout(1500)
             await upload_input.set_input_files(self.thumbnail_portrait_path)
-            await page.wait_for_timeout(2000)
+            await page.wait_for_timeout(3000)
             douyin_logger.info(_msg("🖼️", "竖版封面上传完成"))
 
+        await page.wait_for_timeout(1500)
         await cover_locator.locator('button:visible:has-text("完成")').click()
         douyin_logger.info(_msg("🥳", "视频封面设置完成"))
         await page.wait_for_selector("div.extractFooter", state="detached")
@@ -479,6 +512,24 @@ class DouYinVideo(DouYinBaseUploader):
         context = await set_init_script(context)
 
         page = await context.new_page()
+
+        # 拦截 create_v2 API 响应，捕获 aweme_id (item_id)
+        captured_aweme_id = None
+
+        async def on_response(response):
+            nonlocal captured_aweme_id
+            if '/aweme/create_v2/' in response.url and captured_aweme_id is None:
+                try:
+                    data = await response.json()
+                    if data.get('item_id'):
+                        captured_aweme_id = data['item_id']
+                        print(f"SAU_AWEME_ID:{captured_aweme_id}")
+                        douyin_logger.info(_msg("🔗", f"从API响应捕获 aweme_id: {captured_aweme_id}"))
+                except Exception:
+                    pass
+
+        page.on('response', on_response)
+
         await page.goto("https://creator.douyin.com/creator-micro/content/upload")
         douyin_logger.info(_msg("🏃", f"小人开始搬运视频: {self.title}.mp4"))
         douyin_logger.info(_msg("🧭", "小人正在赶往上传主页"))
@@ -550,6 +601,27 @@ class DouYinVideo(DouYinBaseUploader):
                     timeout=3000,
                 )
                 douyin_logger.success(_msg("🥳", "视频发布成功，小人开心收工"))
+                # 优先用拦截器捕获的 aweme_id（从 create_v2 API 响应获取）
+                if captured_aweme_id:
+                    print(f"SAU_AWEME_ID:{captured_aweme_id}")
+                    douyin_logger.info(_msg("🔗", f"使用捕获的 aweme_id: {captured_aweme_id}"))
+                else:
+                    # 备选：从 manage 页面的视频列表元素提取
+                    try:
+                        await page.wait_for_selector('[class*="video-item"]', timeout=8000)
+                        aweme_id_from_dom = await page.evaluate("""
+                            () => {
+                                const item = document.querySelector('[class*="video-item"]');
+                                return item?.dataset?.awemeId || item?.dataset?.videoId || '';
+                            }
+                        """)
+                        if aweme_id_from_dom:
+                            print(f"SAU_AWEME_ID:{aweme_id_from_dom}")
+                            douyin_logger.info(_msg("🔗", f"从DOM提取 aweme_id: {aweme_id_from_dom}"))
+                        else:
+                            douyin_logger.warning(_msg("⚠️", f"未能提取 aweme_id"))
+                    except Exception:
+                        douyin_logger.warning(_msg("⚠️", f"未能提取 aweme_id"))
                 break
             except Exception:
                 await self.handle_auto_video_cover(page)
@@ -654,6 +726,19 @@ class DouYinNote(DouYinBaseUploader):
                     timeout=3000,
                 )
                 douyin_logger.success(_msg("🥳", "图文发布成功，小人开心收工"))
+                # 提取并打印 aweme_id（供外部程序解析）
+                url = page.url
+                import re
+                m = re.search(r'[?&]aweme_id=(\d+)', url)
+                if not m:
+                    m = re.search(r'aweme_id[=&?](\d+)', url)
+                if not m:
+                    m = re.search(r'/video/(\d{15,})', url)
+                if m:
+                    print(f"SAU_AWEME_ID:{m.group(1)}")
+                    douyin_logger.info(_msg("🔗", f"提取到 aweme_id: {m.group(1)}"))
+                else:
+                    douyin_logger.warning(_msg("⚠️", f"未能从 URL 提取 aweme_id: {url}"))
                 break
             except Exception:
                 douyin_logger.info(_msg("🏃", "小人正在冲刺发布图文"))

--- a/uploader/tencent_uploader/main.py
+++ b/uploader/tencent_uploader/main.py
@@ -82,7 +82,7 @@ async def weixin_setup(account_file, handle=False):
 
 
 class TencentVideo(object):
-    def __init__(self, title, file_path, tags, publish_date: datetime, account_file, category=None, is_draft=False):
+    def __init__(self, title, file_path, tags, publish_date: datetime, account_file, category=None, is_draft=False, thumbnail_landscape_path=None, thumbnail_portrait_path=None, is_original=False):
         self.title = title  # 视频标题
         self.file_path = file_path
         self.tags = tags
@@ -92,6 +92,9 @@ class TencentVideo(object):
         self.headless = LOCAL_CHROME_HEADLESS
         self.is_draft = is_draft  # 是否保存为草稿
         self.local_executable_path = LOCAL_CHROME_PATH or None
+        self.thumbnail_landscape_path = thumbnail_landscape_path
+        self.thumbnail_portrait_path = thumbnail_portrait_path
+        self.is_original = is_original  # 是否声明原创
 
     async def set_schedule_time_tencent(self, page, publish_date):
         label_element = page.locator("label").filter(has_text="定时").nth(1)
@@ -136,6 +139,10 @@ class TencentVideo(object):
         await file_input.set_input_files(self.file_path)
 
     async def upload(self, playwright: Playwright) -> None:
+        # 腾讯视频号上传页面要求非 headless 模式（文件输入框在 headless 下隐藏）
+        self.headless = False
+        if not self.local_executable_path and LOCAL_CHROME_PATH:
+            self.local_executable_path = LOCAL_CHROME_PATH
         # 使用 Chromium (这里使用系统内浏览器，用chromium 会造成h264错误
         browser = await playwright.chromium.launch(headless=self.headless, executable_path=self.local_executable_path)
         # 创建一个浏览器上下文，使用指定的 cookie 文件
@@ -147,9 +154,10 @@ class TencentVideo(object):
         # 访问指定的 URL
         await page.goto("https://channels.weixin.qq.com/platform/post/create")
         tencent_logger.info(f'[+]正在上传-------{self.title}.mp4')
-        # 等待页面跳转到指定的 URL，没进入，则自动等待到超时
-        await page.wait_for_url("https://channels.weixin.qq.com/platform/post/create")
-        # await page.wait_for_selector('input[type="file"]', timeout=10000)
+        # 等待 DOM 加载完成后再等待文件输入框出现
+        await page.wait_for_load_state('domcontentloaded')
+        await asyncio.sleep(3)
+        await page.wait_for_selector('input[type="file"]', state='attached', timeout=60000)
         file_input = page.locator('input[type="file"]')
         await file_input.set_input_files(self.file_path)
         # 填充标题和话题
@@ -158,10 +166,12 @@ class TencentVideo(object):
         # await self.add_product(page)
         # 合集功能
         await self.add_collection(page)
-        # 原创选择
-        await self.add_original(page)
         # 检测上传状态
         await self.detect_upload_status(page)
+        # 原创选择（需在视频上传完成后执行）
+        await self.add_original(page)
+        # 设置封面
+        await self.set_cover(page)
         if self.publish_date != 0:
             await self.set_schedule_time_tencent(page, self.publish_date)
         # 添加短标题
@@ -191,7 +201,7 @@ class TencentVideo(object):
                     # 点击"保存草稿"按钮
                     draft_button = page.locator('div.form-btns button:has-text("保存草稿")')
                     if await draft_button.count():
-                        await draft_button.click()
+                        await draft_button.click(force=True)
                     # 等待跳转到草稿箱页面或确认保存成功
                     await page.wait_for_url("**/post/list**", timeout=5000)  # 使用通配符匹配包含post/list的URL
                     tencent_logger.success("  [-]视频草稿保存成功")
@@ -199,11 +209,16 @@ class TencentVideo(object):
                     # 点击"发表"按钮
                     publish_button = page.locator('div.form-btns button:has-text("发表")')
                     if await publish_button.count():
-                        await publish_button.click()
+                        await publish_button.click(force=True)
                     await page.wait_for_url("https://channels.weixin.qq.com/platform/post/list", timeout=5000)
                     tencent_logger.success("  [-]视频发布成功")
                 break
             except Exception as e:
+                err_msg = str(e)
+                # 浏览器已关闭，直接退出
+                if "Target page, context or browser has been closed" in err_msg:
+                    tencent_logger.info("  [-] 浏览器已关闭，停止等待")
+                    break
                 current_url = page.url
                 if self.is_draft:
                     # 检查是否在草稿相关的页面
@@ -240,6 +255,72 @@ class TencentVideo(object):
                 tencent_logger.info("  [-] 正在上传视频中...")
                 await asyncio.sleep(2)
 
+    async def set_cover(self, page):
+        """设置视频封面"""
+        if not self.thumbnail_portrait_path and not self.thumbnail_landscape_path:
+            tencent_logger.info("  [-] 未设置封面，跳过")
+            return
+        cover_path = self.thumbnail_portrait_path or self.thumbnail_landscape_path
+        if not cover_path:
+            tencent_logger.info("  [-] 封面路径为空，跳过")
+            return
+
+        tencent_logger.info(f"  [-] 开始设置封面: {cover_path}")
+        # 等待页面稳定
+        await asyncio.sleep(5)
+
+        # 先关闭可能还打开着的原创权益弹窗
+        for _ in range(5):
+            try:
+                close_btn = page.locator('.weui-desktop-dialog .weui-desktop-dialog__close-btn')
+                if await close_btn.count() > 0:
+                    await close_btn.click(force=True)
+                    tencent_logger.info("  [-] 关闭了残留弹窗")
+                    await asyncio.sleep(1)
+            except Exception:
+                pass
+            break
+
+        # 点击编辑封面按钮
+        try:
+            edit_btn = page.locator('.edit-btn.edit-btn-zIndex')
+            await edit_btn.click(force=True)
+            tencent_logger.info("  [-] 编辑封面按钮已点")
+        except Exception as e:
+            tencent_logger.error(f"  [-] 点击编辑封面按钮失败: {e}")
+            return
+
+        # 等待对话框出现
+        await asyncio.sleep(5)
+
+        # 直接在隐藏 input 上设置文件
+        try:
+            cover_input = page.locator('.single-cover-uploader-wrap input[type="file"]')
+            await cover_input.set_input_files(cover_path)
+            tencent_logger.info("  [-] 封面文件已设置")
+        except Exception as e:
+            tencent_logger.error(f"  [-] 设置封面文件失败: {e}")
+
+        # 等待封面上传
+        await asyncio.sleep(5)
+
+        # 点确认
+        for _ in range(10):
+            try:
+                confirm = page.locator('.weui-desktop-dialog button:has-text("确认")').first
+                await confirm.click(force=True, timeout=10000)
+                tencent_logger.info("  [-] 封面确认按钮已点")
+                break
+            except Exception as e:
+                tencent_logger.info(f"  [-] 确认按钮点击失败，尝试JS点击: {e}")
+                try:
+                    await page.evaluate('document.querySelector(".weui-desktop-dialog button:has-text(\'确认\')").click()')
+                    tencent_logger.info("  [-] JS点击确认成功")
+                    break
+                except Exception:
+                    pass
+                await asyncio.sleep(2)
+
     async def add_title_tags(self, page):
         await page.locator("div.input-editor").click()
         await page.keyboard.type(self.title)
@@ -257,28 +338,91 @@ class TencentVideo(object):
             await collection_elements.first.click()
 
     async def add_original(self, page):
-        if await page.get_by_label("视频为原创").count():
-            await page.get_by_label("视频为原创").check()
-        # 检查 "我已阅读并同意 《视频号原创声明使用条款》" 元素是否存在
-        label_locator = await page.locator('label:has-text("我已阅读并同意 《视频号原创声明使用条款》")').is_visible()
-        if label_locator:
-            await page.get_by_label("我已阅读并同意 《视频号原创声明使用条款》").check()
-            await page.get_by_role("button", name="声明原创").click()
-        # 2023年11月20日 wechat更新: 可能新账号或者改版账号，出现新的选择页面
-        if await page.locator('div.label span:has-text("声明原创")').count() and self.category:
-            # 因处罚无法勾选原创，故先判断是否可用
-            if not await page.locator('div.declare-original-checkbox input.ant-checkbox-input').is_disabled():
-                await page.locator('div.declare-original-checkbox input.ant-checkbox-input').click()
-                if not await page.locator(
-                        'div.declare-original-dialog label.ant-checkbox-wrapper.ant-checkbox-wrapper-checked:visible').count():
-                    await page.locator('div.declare-original-dialog input.ant-checkbox-input:visible').click()
-            if await page.locator('div.original-type-form > div.form-label:has-text("原创类型"):visible').count():
-                await page.locator('div.form-content:visible').click()  # 下拉菜单
-                await page.locator(
-                    f'div.form-content:visible ul.weui-desktop-dropdown__list li.weui-desktop-dropdown__list-ele:has-text("{self.category}")').first.click()
-                await page.wait_for_timeout(1000)
-            if await page.locator('button:has-text("声明原创"):visible').count():
-                await page.locator('button:has-text("声明原创"):visible').click()
+        if not self.is_original:
+            return
+        try:
+            # 等 checkbox 出现
+            await page.wait_for_selector('span.ant-checkbox', state='attached', timeout=5000)
+            await asyncio.sleep(1)
+
+            # 点第一个 checkbox（原创声明）
+            orig_checkbox = page.get_by_role("checkbox", name="声明后，作品将展示原创标记，有机会获得广告收入。")
+            count = await orig_checkbox.count()
+            tencent_logger.info(f"  [-] 找到原创checkbox: {count} 个")
+
+            if count > 0:
+                await orig_checkbox.check(force=True)
+                tencent_logger.info("  [-] 原创声明已勾选")
+            else:
+                tencent_logger.info("  [-] 未找到原创声明checkbox")
+                return
+
+            # 等待声明原创弹窗出现
+            try:
+                await page.wait_for_selector('.weui-desktop-dialog', state='attached', timeout=5000)
+                tencent_logger.info("  [-] 声明原创弹窗已出现")
+            except Exception:
+                tencent_logger.error("  [-] 声明原创弹窗未出现")
+                return
+
+            # 勾选弹窗里的"同意原创"复选框（必须先勾选才能点声明按钮）
+            try:
+                agree_checkbox = page.locator('.weui-desktop-dialog span.ant-checkbox').first
+                if await agree_checkbox.count() > 0:
+                    # 先尝试正常 check，让 React 状态同步，再兜底 click
+                    try:
+                        await agree_checkbox.check(timeout=3000)
+                    except Exception:
+                        await agree_checkbox.click(force=True)
+                    tencent_logger.info("  [-] 弹窗内同意原创复选框已勾选")
+                    # 等待 React 状态同步，按钮变为可点击
+                    await asyncio.sleep(2)
+            except Exception as e:
+                tencent_logger.warning(f"  [-] 勾选弹窗内同意原创复选框时出错（可能已勾选）: {e}")
+
+            await asyncio.sleep(1)
+
+            # 点弹窗底部的"声明原创"按钮
+            # 精确定位到标题为"原创权益"的弹窗里的、非 disabled 的声明原创按钮
+            declare_btn = page.locator(
+                '.weui-desktop-dialog:has(.weui-desktop-dialog__title:has-text("原创权益")) '
+                '.weui-desktop-dialog__ft div.weui-desktop-btn_wrp:not(.cancel-btn) '
+                'button.weui-desktop-btn_primary:not(.weui-desktop-btn_disabled)'
+            ).first
+            btn_count = await declare_btn.count()
+            tencent_logger.info(f"  [-] 找到声明原创按钮: {btn_count} 个")
+            if btn_count == 0:
+                # 兜底：在标题为"原创权益"的弹窗里找非 disabled 的 primary 按钮
+                declare_btn = page.locator(
+                    '.weui-desktop-dialog:has(.weui-desktop-dialog__title:has-text("原创权益")) '
+                    'button.weui-desktop-btn_primary:not(.weui-desktop-btn_disabled):has-text("声明原创")'
+                ).first
+                btn_count = await declare_btn.count()
+                tencent_logger.info(f"  [-] 兜底找到声明原创按钮: {btn_count} 个")
+
+            if btn_count > 0:
+                try:
+                    await declare_btn.click(timeout=5000)
+                except Exception:
+                    await declare_btn.click(force=True)
+                tencent_logger.info("  [-] 声明原创按钮已点")
+            else:
+                tencent_logger.error("  [-] 未找到声明原创按钮")
+
+            # 等待"原创权益"弹窗关闭（检测可见性，避免DOM残留导致误判）
+            for _ in range(10):
+                try:
+                    is_visible = await page.locator(
+                        '.weui-desktop-dialog__title:has-text("原创权益")'
+                    ).is_visible()
+                except Exception:
+                    is_visible = False
+                if not is_visible:
+                    break
+                tencent_logger.info("  [-] 等待声明原创弹窗关闭...")
+                await asyncio.sleep(1)
+        except Exception as e:
+            tencent_logger.error(f"  [-] 勾选原创声明失败: {e}")
 
     async def main(self):
         async with async_playwright() as playwright:

--- a/uploader/tencent_uploader/main.py
+++ b/uploader/tencent_uploader/main.py
@@ -51,26 +51,61 @@ async def cookie_auth(account_file):
 
 async def get_tencent_cookie(account_file):
     async with async_playwright() as playwright:
+        # 登录必须用 headed 模式，让用户能看到浏览器并扫码
         options = {
-            'args': [
-                '--lang en-GB'
-            ],
-            'headless': LOCAL_CHROME_HEADLESS,  # Set headless option here
+            'args': ['--lang en-GB'],
+            'headless': False,  # 强制 headed，登录需要用户看到浏览器
         }
-        # Make sure to run headed.
         browser = await playwright.chromium.launch(**options)
-        # Setup context however you like.
-        context = await browser.new_context()  # Pass any options
-        # Pause the page, and start recording manually.
+        context = await browser.new_context()
         context = await set_init_script(context)
         page = await context.new_page()
+
+        tencent_logger.info('[+] 正在打开视频号登录页面，请扫码登录...')
         await page.goto("https://channels.weixin.qq.com")
-        await page.pause()
-        # 点击调试器的继续，保存cookie
-        await context.storage_state(path=account_file)
+
+        # 等待登录成功，检测以下任一条件：
+        # 1. URL 从 login 页面跳转到主站
+        # 2. 页面出现"视频号"文字（表示已登录进入后台）
+        # 3. 出现头像/用户名元素
+        login_success = False
+        try:
+            # 等待 URL 变化（登录成功后会跳转到主站）
+            await page.wait_for_url(lambda url: 'channels.weixin.qq.com' in url and 'login' not in url.lower(), timeout=120000)
+            tencent_logger.info('[+] 检测到 URL 变化，登录成功')
+            login_success = True
+        except:
+            pass
+
+        if not login_success:
+            try:
+                # 等待"视频号"文字出现（后台界面）
+                await page.wait_for_selector('text=视频号', timeout=3000)
+                tencent_logger.info('[+] 检测到"视频号"元素，登录成功')
+                login_success = True
+            except:
+                pass
+
+        if not login_success:
+            try:
+                # 等待页面显示用户信息（登录成功后的标志）
+                await page.wait_for_selector('.user-info, [class*="avatar"], img[alt*="头像"]', timeout=3000)
+                tencent_logger.info('[+] 检测到用户信息元素，登录成功')
+                login_success = True
+            except:
+                pass
+
+        # 保存 cookie
+        tencent_logger.info('[+] 正在保存 cookie...')
+        try:
+            await context.storage_state(path=account_file)
+            tencent_logger.success(f'[+] cookie 已保存到: {account_file}')
+        except Exception as e:
+            tencent_logger.error(f'[-] 保存 cookie 失败: {e}')
+            raise
 
 
-async def weixin_setup(account_file, handle=False):
+async def weixin_setup(account_file, handle=False, keep_open=False):
     account_file = get_absolute_path(account_file, "tencent_uploader")
     if not os.path.exists(account_file) or not await cookie_auth(account_file):
         if not handle:
@@ -78,6 +113,13 @@ async def weixin_setup(account_file, handle=False):
             return False
         tencent_logger.info('[+] cookie文件不存在或已失效，即将自动打开浏览器，请扫码登录，登陆后会自动生成cookie文件')
         await get_tencent_cookie(account_file)
+        return True
+
+    if keep_open:
+        tencent_logger.info('[+] cookie 有效，打开浏览器供手动切换账号')
+        await get_tencent_cookie(account_file)
+        return True
+
     return True
 
 


### PR DESCRIPTION
## Summary

修复两个 SAU 投稿问题：

- **封面横竖屏双传**：原 `--thumbnail` 参数只传给 `thumbnail_landscape_path`，竖屏视频封面不会被设置。现在同时传给两个字段，横竖屏封面都能正确上传。
- **aweme_id 捕获**：原从 manage URL 提取 aweme_id 经常失败，现在拦截 `create_v2` API 响应直接获取 `item_id` 作为 aweme_id。

## Changes

- `sau_cli.py`: `DouYinVideo` 初始化时 `thumbnail` 同时传给 `landscape` 和 `portrait`
- `uploader/douyin_uploader/main.py`:
  - 拦截 `create_v2` API 响应捕获 `item_id`（aweme_id）
  - 封面设置延时加大（1.5s/3s）防止浏览器超时
  - `handle_auto_video_cover` 只在未设置封面时干预
  - 封面路径诊断日志（🔍）

## Test plan

- [x] 竖屏视频投稿，封面正常显示
- [x] 横屏视频投稿，封面正常显示  
- [x] aweme_id 正确返回