### PR TITLE
fix(tencent): 视频号「声明原创」缺失时跳过而非中止发布

### DIFF
--- a/uploader/tencent_uploader/main.py
+++ b/uploader/tencent_uploader/main.py
@@ -627,12 +627,13 @@ class TencentBaseUploader(BaseVideoUploader):
             try:
                 diagnostic_path = Path(BASE_DIR) / "debug_tencent_original_missing.png"
                 await page.screenshot(path=str(diagnostic_path), full_page=True)
-                visible_text = (await page.locator("body").inner_text())[-4000:]
+                visible_text = (await page.locator("body").first.inner_text())[-4000:]
                 tencent_logger.warning(_msg("😵", f"未确认声明原创，诊断截图: {diagnostic_path}"))
                 tencent_logger.warning(_msg("🧾", f"页面末尾文本: {visible_text}"))
             except Exception as exc:
                 tencent_logger.warning(_msg("😵", f"生成原创声明诊断信息失败: {exc}"))
-            raise RuntimeError("未能在视频号发布页找到并设置“声明原创”，已停止发布")
+            # 视频号「声明原创」为可选项：页面无对应入口时跳过并继续发布，而非中止。
+            tencent_logger.warning(_msg("📭", "本视频未声明原创（页面无入口或为可选项），跳过并继续发布"))
 
     async def wait_for_upload_complete(self, page: Page) -> None:
         while True:


### PR DESCRIPTION
## 问题

`uploader/tencent_uploader/main.py` 的 `apply_original_statement` 在未能找到「声明原创」入口时会 `raise RuntimeError("未能在视频号发布页找到并设置"声明原创"，已停止发布")`，从而中止整个视频号发布流程。

但视频号的**原创声明本身是可选项**——并非每条视频、每个账号都有这个入口。实际使用中，改版后的发布页（部分账号走 wujie 微前端，DOM 结构与旧版不同）经常匹配不到声明入口，导致本可以正常发布的视频全部失败。

#209 已经大幅改进了声明入口的探测（多重兜底选择器、把声明步骤移到上传完成后、加诊断日志），但在所有探测都失败的兜底分支里仍然保留了这句硬性 `raise`，所以上述场景依然会中止发布。

## 改动

- 在 `if not original_set:` 的兜底分支里，把 `raise RuntimeError(...)` 改为记录一条 `warning` 后**继续发布**，不再中止。诊断截图与页面文本日志保留不变，便于排查。
- 给诊断分支里的 `page.locator("body").inner_text()` 加 `.first`，避免页面存在多个 `<body>`（微前端场景）时触发 Playwright strict mode 报错。

## 影响

- 有原创入口的视频：行为不变（仍会正常勾选声明）。
- 无原创入口的视频：从「直接报错中止」变为「记 warning 并照常发布」。

## 测试

基于此改动，本地用真实视频号账号一键发布多次均成功（含无原创入口的视频），不再因声明原创中止。