### PR TITLE
fix(upload): prevent path traversal in file upload endpoints

### DIFF
--- a/sau_backend.py
+++ b/sau_backend.py
@@ -9,6 +9,7 @@ from queue import Queue
 from flask_cors import CORS
 from myUtils.auth import check_cookie
 from flask import Flask, request, jsonify, Response, render_template, send_from_directory
+from werkzeug.utils import secure_filename
 from conf import BASE_DIR
 from myUtils.login import get_tencent_cookie, douyin_cookie_gen, get_ks_cookie, xiaohongshu_cookie_gen
 from myUtils.postVideo import post_video_tencent, post_video_DouYin, post_video_ks, post_video_xhs
@@ -63,9 +64,12 @@ def upload_file():
         # 保存文件到指定位置
         uuid_v1 = uuid.uuid1()
         print(f"UUID v1: {uuid_v1}")
-        filepath = Path(BASE_DIR / "videoFile" / f"{uuid_v1}_{file.filename}")
+        safe_name = secure_filename(file.filename)
+        if not safe_name:
+            return jsonify({"code": 400, "data": None, "msg": "Invalid filename"}), 400
+        filepath = Path(BASE_DIR / "videoFile" / f"{uuid_v1}_{safe_name}")
         file.save(filepath)
-        return jsonify({"code":200,"msg": "File uploaded successfully", "data": f"{uuid_v1}_{file.filename}"}), 200
+        return jsonify({"code":200,"msg": "File uploaded successfully", "data": f"{uuid_v1}_{safe_name}"}), 200
     except Exception as e:
         return jsonify({"code":500,"msg": str(e),"data":None}), 500
 
@@ -108,9 +112,11 @@ def upload_save():
     # 获取表单中的自定义文件名（可选）
     custom_filename = request.form.get('filename', None)
     if custom_filename:
-        filename = custom_filename + "." + file.filename.split('.')[-1]
+        filename = secure_filename(custom_filename + "." + file.filename.split('.')[-1])
     else:
-        filename = file.filename
+        filename = secure_filename(file.filename)
+    if not filename:
+        return jsonify({"code": 400, "data": None, "msg": "Invalid filename"}), 400
 
     try:
         # 生成 UUID v1


### PR DESCRIPTION
## Vulnerability Summary

**CWE-22 (Path Traversal)** in `sau_backend.py` — the `/upload` and `/uploadSave` endpoints accept user-controlled filenames and pass them directly into `Path()` for `file.save()` without any sanitization. An attacker with network access to port 5409 can craft a filename containing `../` sequences to write files to arbitrary locations on the server's filesystem.

**Affected functions:** `upload_file()` (line 49) and `upload_save()` (line 96) in `sau_backend.py`.

**Severity:** High — arbitrary file write can lead to remote code execution (e.g., overwriting application code, cron jobs, or SSH authorized_keys).

## Data Flow

1. A multipart POST request arrives at `/upload` or `/uploadSave`
2. `file = request.files['file']` extracts the uploaded file
3. `file.filename` (attacker-controlled) is used directly in `Path(BASE_DIR / "videoFile" / f"{uuid_v1}_{file.filename}")`
4. `file.save(filepath)` writes to the constructed path

A filename like `../../etc/cron.d/backdoor` causes the file to be written outside the intended `videoFile/` directory.

## Proof of Concept

```bash
# Write a file outside the upload directory via /upload
curl -X POST http://<target>:5409/upload \
  -F "file=@payload.txt;filename=../../../tmp/pwned.txt"

# Verify the file landed at /tmp/pwned.txt instead of videoFile/
ls -la /tmp/pwned.txt
```

For `/uploadSave`, the `custom_filename` form field is also unsanitized:

```bash
curl -X POST http://<target>:5409/uploadSave \
  -F "file=@payload.txt" \
  -F "filename=../../../tmp/pwned"
```

Both endpoints have no authentication and the server binds `0.0.0.0:5409`, so any host with network access can exploit this.

## Fix Description

This PR applies `werkzeug.utils.secure_filename()` to all user-supplied filenames before they are used in path construction. `secure_filename()` strips directory separators, leading dots, and other dangerous characters, collapsing the filename to a flat, safe basename.

Additionally, an empty-filename guard is added — `secure_filename()` can return an empty string for adversarial inputs (e.g., `"../../"`), and the fix now returns a 400 error in that case rather than proceeding with a broken path.

Changes are confined to `sau_backend.py`:
- Added `from werkzeug.utils import secure_filename`
- Applied `secure_filename()` in `upload_file()` and `upload_save()`
- Added empty-filename validation after sanitization

## Testing

- Verified that normal filenames (e.g., `video.mp4`, `my file (1).mp4`) pass through `secure_filename()` correctly and are saved to the intended `videoFile/` directory.
- Verified that traversal payloads (`../../../etc/passwd`, `....//....//tmp/x`) are sanitized to flat filenames.
- Verified that adversarial filenames that reduce to empty strings (e.g., `../../`) return a 400 error.
- Confirmed `werkzeug` is already a dependency (Flask depends on it), so no new dependencies are introduced.

## Adversarial Review

Before submitting, we considered whether existing protections might prevent exploitation. The endpoints have no authentication (`check_cookie` is imported but not used as a decorator on these routes), no filename validation, and no middleware-level path restrictions. The server binds `0.0.0.0`, making it reachable from the network. CORS is configured with `flask_cors.CORS(app)` using default settings (all origins allowed). There are no mitigations that would prevent this attack.