### PR TITLE
feat(douyin): 发布时自动选择「自主声明」；fix(xiaohongshu): 话题候选超时不再中断发布

### DIFF
--- a/uploader/douyin_uploader/main.py
+++ b/uploader/douyin_uploader/main.py
@@ -367,6 +367,35 @@ class DouYinBaseUploader(BaseVideoUploader):
             douyin_logger.error(_msg("😢", f"设置商品链接时出错: {str(e)}"))
             return False
 
+    async def set_self_declaration(self, page: Page, declaration: str = "内容为个人观点或见解") -> None:
+        """抖音「自主声明」为发布必选项：打开声明弹窗 → 选指定类型 → 确定。
+
+        入口和弹窗都是异步渲染，等不到就记 warning 跳过、继续发布，绝不因此中断
+        （与小红书话题、视频号声明原创的容错策略保持一致）。
+        """
+        try:
+            # 发布页底部「自主声明」行，未选时显示占位文案「请选择自主声明」
+            entry = page.get_by_text("请选择自主声明").first
+            await entry.wait_for(state="visible", timeout=6000)
+            await entry.click()
+
+            # 弹窗标题「对作品内容添加声明」
+            dialog = page.locator(".semi-modal-content").filter(has_text="对作品内容添加声明").first
+            await dialog.wait_for(state="visible", timeout=6000)
+
+            # 单选项：Semi 的文字是 .semi-radio-addon（常带 pointer-events:none，直接点会卡 30s 超时），
+            # 要点可交互的 .semi-radio 外层；找不到外层再退回 force 强制点文字。exact 避免误命中预览「作者声明：…」。
+            option = dialog.locator(".semi-radio").filter(has_text=declaration).first
+            if await option.count():
+                await option.click(timeout=6000)
+            else:
+                await dialog.get_by_text(declaration, exact=True).first.click(timeout=6000, force=True)
+            await dialog.get_by_role("button", name="确定").click(timeout=6000)
+            await dialog.wait_for(state="hidden", timeout=6000)
+            douyin_logger.info(_msg("🧾", f"自主声明已选择「{declaration}」"))
+        except Exception as exc:
+            douyin_logger.warning(_msg("🧾", f"自主声明设置失败，跳过该步骤继续发布：{exc}"))
+
 
 class DouYinVideo(DouYinBaseUploader):
     def __init__(
@@ -531,6 +560,8 @@ class DouYinVideo(DouYinBaseUploader):
             douyin_logger.info(_msg("🥳", "商品链接设置完成"))
 
         await self.set_thumbnail(page)
+
+        await self.set_self_declaration(page)
 
         third_part_element = '[class^="info"] > [class^="first-part"] div div.semi-switch'
         if await page.locator(third_part_element).count():

--- a/uploader/xiaohongshu_uploader/main.py
+++ b/uploader/xiaohongshu_uploader/main.py
@@ -400,14 +400,25 @@ class XiaoHongShuBaseUploader(BaseVideoUploader):
             await desc.click()
 
         for tag in self.tags:  # 循环处理所有 tags
-            await page.keyboard.type("#" + tag, delay=30)
-            await page.locator('#creator-editor-topic-container').wait_for(
-                state="visible",
-                timeout=3000
-            )
-            first_item = page.locator('#creator-editor-topic-container .item').first
-            await first_item.wait_for(state="visible", timeout=2000)
-            await first_item.click()
+            # 话题候选下拉框依赖小红书联想接口实时返回，网络抖动/无匹配时会等不到。
+            # 标签是可选增强项：等不到候选框就跳过该标签继续，不让整条发布因此失败。
+            try:
+                await page.keyboard.type("#" + tag, delay=30)
+                await page.locator('#creator-editor-topic-container').wait_for(
+                    state="visible",
+                    timeout=6000
+                )
+                first_item = page.locator('#creator-editor-topic-container .item').first
+                await first_item.wait_for(state="visible", timeout=4000)
+                await first_item.click()
+            except Exception as exc:
+                xiaohongshu_logger.warning(
+                    _msg("🏷️", f"话题『{tag}』未出现候选，跳过该标签继续发布: {exc}")
+                )
+                # 清掉已键入但未成词的 "#tag" 文本，避免它残留进正文
+                for _ in range(len("#" + tag)):
+                    await page.keyboard.press("Backspace")
+                continue
 
     async def fill_meta(self, page: Page) -> None:
         await self.fill_title(page)


### PR DESCRIPTION
## 改动概述

本 PR 包含两处与发布流程稳健性相关的改动，都遵循同一原则：**可选/附加步骤失败时跳过并继续发布，绝不中断主流程**。

---

### 1. feat(douyin)：发布时自动选择「自主声明」

抖音创作者中心发布页的「自主声明」是**必选项**，但当前 `DouYinVideo` 发布流程未处理，会留空。

- 新增 `DouYinBaseUploader.set_self_declaration()`：点开占位「请选择自主声明」→ 在弹窗「对作品内容添加声明」中单选声明类型 → 「确定」。
- 默认选择「内容为个人观点或见解」，可通过方法参数 `declaration` 调整。
- 在 `DouYinVideo` 贴完封面后调用。
- **容错**：入口与弹窗均异步渲染，等不到则记 `warning` 跳过、继续发布；`exact=True` 避免误命中弹窗预览里的「作者声明：…」文案。
- 范围：仅视频（`DouYinVideo`），图文 `DouYinNote` 暂未涉及。

### 2. fix(xiaohongshu)：话题候选等不到时跳过该标签，而非中断整条发布

`fill_tags` 对每个标签等待联想下拉 `#creator-editor-topic-container`，**网络抖动或无匹配**时会超时，导致整条发布 `Timeout` 失败。

- 改为 `try/except`：超时（等待放宽 3s/2s → 6s/4s）则退格清掉已键入的 `#tag` 残留文本、`warning` 跳过该标签、继续发布。
- 标签为可选增强项，不应阻断主流程。

---

### 说明

- 小红书改动已在实际发布中验证。
- 抖音改动针对当前创作者中心发布页结构实现；弹窗结构若变动，未命中时会安全跳过（不影响发布），不会让发布更糟。
