### PR TITLE
fix: avoid f-string backslash syntax error in xiaohongshu uploader

### DIFF
--- a/uploader/xiaohongshu_uploader/main.py
+++ b/uploader/xiaohongshu_uploader/main.py
@@ -515,7 +515,8 @@ class XiaoHongShuVideo(XiaoHongShuBaseUploader):
                         break
                     
                     if self.debug:
-                        xiaohongshu_logger.debug(_msg("🧍", f"预览区域内容: {all_text.strip().replace('\\n', ' ')}"))
+                        normalized_text = all_text.strip().replace("\n", " ")
+                        xiaohongshu_logger.debug(_msg("🧍", f"预览区域内容: {normalized_text}"))
                     xiaohongshu_logger.debug(_msg("🧍", "还没看到上传成功标识，小人继续等一会"))
                 else:
                     # 尝试检查标题输入框是否已经出现，如果是，说明已经进入编辑状态


### PR DESCRIPTION
## Summary
- move newline normalization out of an f-string expression in `uploader/xiaohongshu_uploader/main.py`
- prevent `SyntaxError: f-string expression part cannot include a backslash` when importing CLI modules
- keep existing debug log message behavior unchanged

## Test plan
- [x] run `uv run sau --help`
- [x] run `uv run sau xiaohongshu upload-note --help`
- [x] verify the command exits without syntax errors