### PR TITLE
fix(douyin): initialize original_url/saw_2fa/i in login wait loop

### DIFF
--- a/uploader/douyin_uploader/main.py
+++ b/uploader/douyin_uploader/main.py
@@ -172,7 +172,9 @@ async def _is_douyin_login_completed(page: Page) -> bool:
 
 async def _wait_for_douyin_login(page: Page, account_file: str, qrcode_info: dict, qrcode_callback=None, poll_interval: int = 3, max_checks: int = 100) -> dict:
     qrcode_path = Path(qrcode_info["image_path"]) if qrcode_info.get("image_path") else None
-    for _ in range(max_checks):
+    original_url = page.url
+    saw_2fa = False
+    for i in range(max_checks):
         if await _is_douyin_login_completed(page):
             douyin_logger.info(_msg("🥳", f"扫码成功，已经跳转到登录后页面: {page.url}"))
             return _build_login_result(True, "success", "抖音扫码登录成功", account_file, qrcode_info, page.url)
@@ -222,7 +224,7 @@ async def douyin_cookie_gen(
         result = _build_login_result(False, "failed", "抖音登录失败", account_file)
         try:
             page = await context.new_page()
-            await page.goto("https://creator.douyin.com/")
+            await page.goto("https://creator.douyin.com/", wait_until="domcontentloaded", timeout=60000)
             qrcode_info = await _save_douyin_qrcode(page, account_file, qrcode_callback=qrcode_callback)
             qrcode_path = Path(qrcode_info["image_path"]) if qrcode_info.get("image_path") else None
             douyin_logger.info(_msg("🧍", "请扫码，小人正在耐心等待登录完成"))


### PR DESCRIPTION
## Problem

The auto-login overhaul in #229 introduced a `NameError` that crashes **every** Douyin scan-login attempt:

```
😢 登录失败: name 'original_url' is not defined
```

`_wait_for_douyin_login` references three names that are never defined:
- `original_url` (line ~183, URL-change / 2FA detection)
- `saw_2fa` (line ~186, dedup the 2FA warning)
- `i` (line ~187, progress counter `{i}/{max_checks}`) — the loop is `for _ in range(...)`

Because the `NameError` fires on the first poll iteration, login never completes and no cookie is saved.

## Fix

- initialize `original_url = page.url` and `saw_2fa = False` before the loop
- rename the loop variable `_` → `i`

## Bonus: SPA goto timeout

`creator.douyin.com` is a slow SPA. The bare `page.goto("https://creator.douyin.com/")` waits for the `load` event and frequently hits Playwright's 30s default timeout before the QR card renders. Switched to `wait_until="domcontentloaded"` with an explicit 60s timeout so the QR code can be extracted reliably.

## Testing

With this patch, headed scan-login completes end-to-end (including manual SMS/slider 2FA) and the cookie is persisted + validated on a real account.