### PR TITLE
feat(uploader): expose --cdp-url for xiaohongshu/tencent/youtube login + WSL guide

### DIFF
--- a/docs/WSL-USER-GUIDE.md
+++ b/docs/WSL-USER-GUIDE.md
@@ -1,0 +1,219 @@
+# WSL2 用户指南
+
+> 适用对象: 在 WSL2 (Windows Subsystem for Linux) 环境下使用 social-auto-upload 的用户。
+> 也适用于: 任何 Linux server / Linux 桌面环境 (无 GUI 或装了 patchright 但没装系统 Chrome)。
+
+本文汇总 SAU 在类 Unix 环境下的踩坑与对应绕过方案,每节末尾给出"一句话总结"。
+
+---
+
+## 1. 抖音扫码登录 headless 模式被反爬墙识别
+
+**症状**: `sau douyin login --account foo` 在 `--headless` 模式下反复报 `cookie 已失效`,
+但实际 cookie 文件存在;或者扫码后页面跳转过快,被检测为 bot。
+
+**原因**: 抖音创作者中心的反爬墙模块对无头浏览器 (headless) 检测敏感,经常将正常的扫码登录误判为 bot 失效。
+
+**解决**: 默认走 headed 模式 (即默认 `--headed`,不传 `--headless`)。
+如确实需要无头 (CI/CD / 服务器),显式设 `DOUYIN_COOKIE_AUTH_HEADLESS=true`:
+
+```bash
+# 推荐:headed 模式
+sau douyin login --account myaccount --headed
+
+# CI/CD 才用 headless
+DOUYIN_COOKIE_AUTH_HEADLESS=true sau douyin login --account myaccount --headless
+```
+
+**一句话总结**: 抖音登录默认用 headed,只在 CI 里才开 headless。
+
+---
+
+## 2. Chrome 默认绑 IPv6 `::1:9222`,WSL2 无法访问
+
+**症状**: `sau douyin login --cdp-url http://172.19.224.1:9222` 连不上 Windows 上的 Chrome DevTools。
+
+**原因**: Chrome 111+ 移除了 `--remote-debugging-address` flag,只剩 `--remote-debugging-port`。
+Chrome 默认绑 IPv6 `::1:9222` (dual-stack socket 在 Windows 优先 IPv6 loopback),而:
+- WSL 的 IPv6 namespace 跟 Windows 不通 → `[::1]:9222` 失败
+- WSL 自己的 IPv4 `127.0.0.1:9222` 是 WSL 的 loopback,不是 Windows 的 → 失败
+- WSL 唯一能访问的 Windows IP 是 `172.19.224.1` (vEthernet (WSL) 适配器)
+
+**解决**: 在 Windows 桌面跑一个 IPv4→IPv6 TCP proxy,转发 `0.0.0.0:9222` → `[::1]:9222`。
+
+### 2.1. IPv4→IPv6 TCP proxy (Python)
+
+把这个脚本保存到 `C:\Users\Admin\AppData\Local\Temp\chrome_cdp_proxy.py`:
+
+```python
+import asyncio
+
+async def relay(reader, writer, label):
+    try:
+        while True:
+            data = await reader.read(65536)
+            if not data: break
+            writer.write(data); await writer.drain()
+    finally:
+        writer.close()
+
+async def handle(cr, cw):
+    tr, tw = await asyncio.open_connection("::1", 9222)
+    await asyncio.gather(relay(cr, tw, "c->t"), relay(tr, cw, "t->c"))
+
+async def main():
+    s = await asyncio.start_server(handle, "0.0.0.0", 9222, reuse_address=True)
+    async with s: await s.serve_forever()
+
+asyncio.run(main())
+```
+
+启动 (PowerShell,后台运行):
+```powershell
+Start-Process -FilePath 'C:\Users\Admin\AppData\Local\Programs\Python\Python312\python.exe' `
+  -ArgumentList '-u','C:\Users\Admin\AppData\Local\Temp\chrome_cdp_proxy.py' `
+  -RedirectStandardOutput 'C:\Users\Admin\AppData\Local\Temp\cdp_proxy.log' `
+  -WindowStyle Hidden
+```
+
+⚠️ **必须先删除 netsh portproxy**: `netsh interface portproxy delete v4tov4 listenport=9222` —
+proxy 自己要 bind 9222 端口,不能跟 portproxy 抢。
+
+### 2.2. 在桌面双击 .bat 启动 Chrome (有 UI)
+
+Chrome 通过 WSL interop (`powershell.exe Start-Process chrome.exe`) 启动会跑到 Session 0,
+**没有 UI 窗口**,无法扫码。**必须用户在桌面双击 .bat** 启动。
+
+把下面保存为 `C:\Users\Admin\Desktop\SAU-Login-Chrome.bat`:
+
+```bat
+@echo off
+taskkill /F /IM chrome.exe /T 2>nul
+timeout /t 3 /nobreak >nul
+start "" "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir=%TEMP%\chrome-sau-login --remote-allow-origins=* "https://creator.douyin.com/"
+exit
+```
+
+⚠️ **.bat 必须纯 ASCII**: UTF-8 中文 echo 在 cmd GBK 下变乱码当命令执行,会崩溃。
+注释也写英文。
+
+按需修改启动 URL:
+- 抖音: `https://creator.douyin.com/`
+- 快手: `https://cp.kuaishou.com/`
+- B 站: `https://member.bilibili.com/`
+
+### 2.3. WSL 端验证
+
+```bash
+# 确认 proxy 在听
+curl -s http://172.19.224.1:9222/json/version | head
+
+# 用 SAU 接 CDP
+sau douyin login --account myaccount --headed --cdp-url http://172.19.224.1:9222
+```
+
+**一句话总结**: Chrome 必须桌面启动 + Windows 跑 IPv4→IPv6 proxy + WSL 通过 `172.19.224.1:9222` 接。
+
+---
+
+## 3. 系统找不到 Chrome: `Chromium distribution 'chrome' is not found`
+
+**症状**:
+```
+playwright._impl._errors.Error: Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome
+```
+
+**原因**: SAU 默认 `channel="chrome"`,Playwright 会去找系统装的 Google Chrome。
+WSL2 Kali 通常没装,只有 patchright bundled 的 Chromium。
+
+**解决 (v0.3.0+ 默认行为)**: SAU 已默认改用 `chromium` channel (patchright bundled),无需任何操作。
+
+需要强制用系统 Chrome:
+```bash
+SAU_BROWSER_CHANNEL=chrome sau douyin login --account myaccount
+```
+
+需要 Edge:
+```bash
+SAU_BROWSER_CHANNEL=msedge sau douyin login --account myaccount
+```
+
+**一句话总结**: 默认用 bundled chromium,设 `SAU_BROWSER_CHANNEL=chrome` 切回系统 Chrome。
+
+---
+
+## 4. `--cdp-url` 让 WSL 用户用桌面 Chrome 扫码
+
+**症状**: 想用 Windows 上已经登录好的 Chrome (有 UI) 扫码,但 SAU 默认会启动新的 headless Chromium。
+
+**解决**: 所有 Playwright-based 平台 (`douyin`, `kuaishou`, `xiaohongshu`, `tencent`, `youtube`) 现在都支持 `--cdp-url`:
+
+```bash
+sau <platform> login --account myaccount --headed --cdp-url http://172.19.224.1:9222
+```
+
+前置条件: Chrome 必须在 Windows 桌面用 `.bat` 启动并带 `--remote-debugging-port=9222`
+(参见 §2)。SAU 通过 `connect_over_cdp` 接到现有 Chrome,扫完码保存 cookie,**不会关掉你的 Chrome**。
+
+⚠️ **不支持 `--cdp-url` 的平台**: `bilibili` (用 biliup CLI 而不是 Playwright)。
+
+**一句话总结**: `--cdp-url` 把 SAU 接到桌面 Chrome,扫码后 Chrome 不会被关掉。
+
+---
+
+## 5. Chrome `--user-data-dir` 必须保留
+
+**症状**: 每次跑 `sau douyin login` 都要重新扫码,之前登录态丢了。
+
+**原因**: Chrome 不带 `--user-data-dir` 时,每次启动都新建临时 profile,cookie / login state 都不持久。
+
+**解决**: `.bat` 启动 Chrome 时显式指定固定目录 (例子里用的是 `%TEMP%\chrome-sau-login`,
+重启电脑后 `%TEMP%` 被清空,**Windows 桌面建议改成 `%USERPROFILE%\AppData\Local\chrome-sau-login`**):
+
+```bat
+@echo off
+taskkill /F /IM chrome.exe /T 2>nul
+timeout /t 3 /nobreak >nul
+start "" "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir=%USERPROFILE%\AppData\Local\chrome-sau-login --remote-allow-origins=* "https://creator.douyin.com/"
+exit
+```
+
+**一句话总结**: Chrome 启动必须带 `--user-data-dir=固定路径`,否则每次都得重新登录。
+
+---
+
+## 6. Windows .bat 不能含 UTF-8 中文
+
+**症状**: 双击 .bat 立即弹出 cmd 窗口又关掉,或报"找不到命令"。
+
+**原因**: Windows cmd 默认 GBK 编码,UTF-8 BOM 文件的中文 echo 会被解析为乱码命令并执行失败。
+
+**解决**: `.bat` 文件保存为 ANSI / GBK / 纯 ASCII。注释也写英文。
+
+**一句话总结**: `.bat` 文件**永远不要含中文**,包括注释。
+
+---
+
+## 7. 完整 WSL2 工作流示例 (抖音)
+
+```bash
+# 一次性 setup (Windows 桌面 PowerShell)
+#   1. 把 §2.1 的 Python proxy 保存到 C:\Users\Admin\AppData\Local\Temp\chrome_cdp_proxy.py
+#   2. 启动 proxy: Start-Process python.exe -ArgumentList '-u', 'C:\...\chrome_cdp_proxy.py' ...
+#   3. 桌面双击 §2.2 的 .bat,Chrome 弹出并打开 https://creator.douyin.com/
+#   4. (可选) 在 Chrome 里手动登录抖音,这样 cookie 就存到 user-data-dir
+
+# WSL 端日常使用
+source ~/.local/bin/proxy_switch.sh auto   # 网络命令前激活代理
+sau douyin login --account myaccount --headed --cdp-url http://172.19.224.1:9222
+sau douyin upload-video --account myaccount --file ./video.mp4 --title "标题" --tags "tag1,tag2"
+```
+
+---
+
+## 8. 相关链接
+
+- [install.md](./install.md) — 基础安装
+- [CLI.md](./CLI.md) — 命令行参数全表
+- [OpenClaw issue #108262](https://github.com/openclaw/openclaw/issues/108262) — agent fallback bug
+  (与本指南无关,但常一起被踩到)

--- a/sau_cli.py
+++ b/sau_cli.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import shutil
+import sqlite3
 import sys
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -145,6 +148,7 @@ class BilibiliVideoUploadRequest:
     tid: int
     tags: list[str]
     publish_date: datetime | int
+    thumbnail_file: Path | None = None
 
 
 @dataclass(slots=True)
@@ -216,9 +220,67 @@ def parse_schedule(raw_schedule: str | None) -> datetime | int:
     return datetime.strptime(raw_schedule, SCHEDULE_FORMAT)
 
 
-async def login_douyin_account(account_name: str, headless: bool = True) -> dict:
+def register_cli_cookie_to_webui(platform: str, account_name: str, cookie_path: str):
+    """将CLI登录的cookie注册到Web UI账号表，使前端可见。"""
+    platform_type_map = {
+        "xiaohongshu": 1,
+        "tencent": 2,
+        "douyin": 3,
+        "kuaishou": 4,
+    }
+    platform_type = platform_type_map.get(platform)
+    if not platform_type:
+        print(f"[register] 未知平台: {platform}")
+        return
+
+    new_filename = f"{uuid.uuid1()}.json"
+    target_dir = Path(BASE_DIR) / "cookiesFile"
+    target_dir.mkdir(exist_ok=True)
+    target_path = target_dir / new_filename
+
+    shutil.copy2(cookie_path, target_path)
+
+    db_path = Path(BASE_DIR) / "db" / "database.db"
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    existing = cursor.execute(
+        "SELECT id FROM user_info WHERE type = ? AND userName = ?",
+        (platform_type, account_name),
+    ).fetchone()
+
+    if existing:
+        cursor.execute(
+            "UPDATE user_info SET filePath = ?, status = 1 WHERE id = ?",
+            (new_filename, existing[0]),
+        )
+        print(f"[register] 已更新Web UI账号: {platform}/{account_name}")
+    else:
+        cursor.execute(
+            "INSERT INTO user_info (type, filePath, userName, status) VALUES (?, ?, ?, 1)",
+            (platform_type, new_filename, account_name),
+        )
+        print(f"[register] 已注册到Web UI: {platform}/{account_name}")
+
+    conn.commit()
+
+    # Clean up any cookiesFile blobs no longer referenced by user_info
+    referenced = {
+        row[0]
+        for row in cursor.execute("SELECT filePath FROM user_info").fetchall()
+    }
+    for path in target_dir.iterdir():
+        if path.is_file() and path.name not in referenced:
+            path.unlink(missing_ok=True)
+
+    conn.close()
+
+
+async def login_douyin_account(account_name: str, headless: bool = True, cdp_url: str | None = None) -> dict:
     account_file = resolve_account_file("douyin", account_name)
-    return await douyin_setup(str(account_file), handle=True, return_detail=True, headless=headless)
+    result = await douyin_setup(str(account_file), handle=True, return_detail=True, headless=headless, cdp_url=cdp_url)
+    if result["success"]:
+        register_cli_cookie_to_webui("douyin", account_name, str(account_file))
+    return result
 
 
 async def check_douyin_account(account_name: str) -> bool:
@@ -228,9 +290,12 @@ async def check_douyin_account(account_name: str) -> bool:
     return await douyin_cookie_auth(str(account_file))
 
 
-async def login_kuaishou_account(account_name: str, headless: bool = True) -> dict:
+async def login_kuaishou_account(account_name: str, headless: bool = True, cdp_url: str | None = None) -> dict:
     account_file = resolve_account_file("kuaishou", account_name)
-    return await ks_setup(str(account_file), handle=True, return_detail=True, headless=headless)
+    result = await ks_setup(str(account_file), handle=True, return_detail=True, headless=headless, cdp_url=cdp_url)
+    if result["success"]:
+        register_cli_cookie_to_webui("kuaishou", account_name, str(account_file))
+    return result
 
 
 async def check_kuaishou_account(account_name: str) -> bool:
@@ -240,9 +305,9 @@ async def check_kuaishou_account(account_name: str) -> bool:
     return await kuaishou_cookie_auth(str(account_file))
 
 
-async def login_xiaohongshu_account(account_name: str, headless: bool = True) -> dict:
+async def login_xiaohongshu_account(account_name: str, headless: bool = True, cdp_url: str | None = None) -> dict:
     account_file = resolve_account_file("xiaohongshu", account_name)
-    return await xiaohongshu_setup(str(account_file), handle=True, return_detail=True, headless=headless)
+    return await xiaohongshu_setup(str(account_file), handle=True, return_detail=True, headless=headless, cdp_url=cdp_url)
 
 
 async def check_xiaohongshu_account(account_name: str) -> bool:
@@ -282,9 +347,9 @@ async def check_bilibili_account(account_name: str) -> bool:
     return result.returncode == 0
 
 
-async def login_tencent_account(account_name: str, headless: bool = True) -> dict:
+async def login_tencent_account(account_name: str, headless: bool = True, cdp_url: str | None = None) -> dict:
     account_file = resolve_account_file("tencent", account_name)
-    return await tencent_setup(str(account_file), handle=True, return_detail=True, headless=headless)
+    return await tencent_setup(str(account_file), handle=True, return_detail=True, headless=headless, cdp_url=cdp_url)
 
 
 async def check_tencent_account(account_name: str) -> bool:
@@ -294,9 +359,9 @@ async def check_tencent_account(account_name: str) -> bool:
     return await tencent_cookie_auth(str(account_file))
 
 
-async def login_youtube_account(account_name: str, headless: bool = False) -> dict:
+async def login_youtube_account(account_name: str, headless: bool = False, cdp_url: str | None = None) -> dict:
     account_file = resolve_account_file("youtube", account_name)
-    return await youtube_setup(str(account_file), handle=True, return_detail=True, headless=headless)
+    return await youtube_setup(str(account_file), handle=True, return_detail=True, headless=headless, cdp_url=cdp_url)
 
 
 async def check_youtube_account(account_name: str) -> bool:
@@ -501,6 +566,8 @@ async def upload_bilibili_video(request: BilibiliVideoUploadRequest) -> Path:
     ]
     if request.tags:
         arguments.extend(["--tag", ",".join(request.tags)])
+    if request.thumbnail_file:
+        arguments.extend(["--cover", str(request.thumbnail_file)])
     if isinstance(request.publish_date, datetime):
         arguments.extend(["--dtime", str(int(request.publish_date.timestamp()))])
 
@@ -584,6 +651,7 @@ def build_parser() -> argparse.ArgumentParser:
         action_parser.add_argument("--account", required=True, help="Douyin user-defined account_name")
         if action_name == "login":
             add_runtime_flags(action_parser)
+            action_parser.add_argument("--cdp-url", help="Attach to an existing Chrome via CDP, e.g. http://127.0.0.1:9222")
 
     upload_video_parser = douyin_actions.add_parser("upload-video", help="Upload one video to Douyin")
     upload_video_parser.add_argument("--account", required=True, help="Douyin user-defined account_name")
@@ -618,6 +686,7 @@ def build_parser() -> argparse.ArgumentParser:
         action_parser.add_argument("--account", required=True, help="Kuaishou user-defined account_name")
         if action_name == "login":
             add_runtime_flags(action_parser)
+            action_parser.add_argument("--cdp-url", help="Attach to an existing Chrome via CDP, e.g. http://127.0.0.1:9222")
 
     kuaishou_upload_video_parser = kuaishou_actions.add_parser("upload-video", help="Upload one video to Kuaishou")
     kuaishou_upload_video_parser.add_argument("--account", required=True, help="Kuaishou user-defined account_name")
@@ -646,6 +715,7 @@ def build_parser() -> argparse.ArgumentParser:
         action_parser.add_argument("--account", required=True, help="Xiaohongshu user-defined account_name")
         if action_name == "login":
             add_runtime_flags(action_parser)
+            action_parser.add_argument("--cdp-url", help="Attach to an existing Chrome via CDP, e.g. http://127.0.0.1:9222")
 
     xiaohongshu_upload_video_parser = xiaohongshu_actions.add_parser("upload-video", help="Upload one video to Xiaohongshu")
     xiaohongshu_upload_video_parser.add_argument("--account", required=True, help="Xiaohongshu user-defined account_name")
@@ -680,6 +750,7 @@ def build_parser() -> argparse.ArgumentParser:
     bilibili_upload_video_parser.add_argument("--desc", required=True, help="Video description")
     bilibili_upload_video_parser.add_argument("--tid", required=True, type=int, help="Bilibili category id")
     bilibili_upload_video_parser.add_argument("--tags", default="", help="Comma-separated tags, such as tag1,tag2")
+    bilibili_upload_video_parser.add_argument("--thumbnail", type=existing_file_path, help="Optional Bilibili cover image path")
     bilibili_upload_video_parser.add_argument("--schedule", type=schedule_value, help=f"Schedule time in {schedule_help}")
 
     tencent_parser = platform_parsers.add_parser("tencent", help="Tencent/WeChat Channels operations")
@@ -690,6 +761,7 @@ def build_parser() -> argparse.ArgumentParser:
         action_parser.add_argument("--account", required=True, help="Tencent user-defined account_name")
         if action_name == "login":
             add_runtime_flags(action_parser)
+            action_parser.add_argument("--cdp-url", help="Attach to an existing Chrome via CDP, e.g. http://127.0.0.1:9222")
 
     tencent_upload_video_parser = tencent_actions.add_parser("upload-video", help="Upload one video to WeChat Channels")
     tencent_upload_video_parser.add_argument("--account", required=True, help="Tencent user-defined account_name")
@@ -714,6 +786,7 @@ def build_parser() -> argparse.ArgumentParser:
         action_parser.add_argument("--account", required=True, help="YouTube user-defined account_name")
         if action_name == "login":
             add_runtime_flags(action_parser)
+            action_parser.add_argument("--cdp-url", help="Attach to an existing Chrome via CDP, e.g. http://127.0.0.1:9222")
 
     youtube_upload_video_parser = youtube_actions.add_parser("upload-video", help="Upload one video to YouTube")
     youtube_upload_video_parser.add_argument("--account", required=True, help="YouTube user-defined account_name")
@@ -732,7 +805,7 @@ def build_parser() -> argparse.ArgumentParser:
 async def dispatch(args: argparse.Namespace) -> int:
     if args.platform == "douyin":
         if args.action == "login":
-            result = await login_douyin_account(args.account, headless=args.headless)
+            result = await login_douyin_account(args.account, headless=args.headless, cdp_url=args.cdp_url)
             if not result["success"]:
                 raise RuntimeError(result["message"])
             print(f"Douyin login flow completed: {result['account_file']}")
@@ -796,7 +869,7 @@ async def dispatch(args: argparse.Namespace) -> int:
 
     if args.platform == "kuaishou":
         if args.action == "login":
-            result = await login_kuaishou_account(args.account, headless=args.headless)
+            result = await login_kuaishou_account(args.account, headless=args.headless, cdp_url=args.cdp_url)
             if not result["success"]:
                 raise RuntimeError(result["message"])
             print(f"Kuaishou login flow completed: {result['account_file']}")
@@ -846,7 +919,7 @@ async def dispatch(args: argparse.Namespace) -> int:
 
     if args.platform == "xiaohongshu":
         if args.action == "login":
-            result = await login_xiaohongshu_account(args.account, headless=args.headless)
+            result = await login_xiaohongshu_account(args.account, headless=args.headless, cdp_url=args.cdp_url)
             if not result["success"]:
                 raise RuntimeError(result["message"])
             print(f"Xiaohongshu login flow completed: {result['account_file']}")
@@ -926,6 +999,7 @@ async def dispatch(args: argparse.Namespace) -> int:
                 tid=args.tid,
                 tags=parse_tags(args.tags),
                 publish_date=args.schedule or 0,
+                thumbnail_file=args.thumbnail,
             )
             await upload_bilibili_video(request)
             print(f"Bilibili video upload submitted: {request.video_file}")
@@ -935,7 +1009,7 @@ async def dispatch(args: argparse.Namespace) -> int:
 
     if args.platform == "tencent":
         if args.action == "login":
-            result = await login_tencent_account(args.account, headless=args.headless)
+            result = await login_tencent_account(args.account, headless=args.headless, cdp_url=args.cdp_url)
             if not result["success"]:
                 raise RuntimeError(result["message"])
             print(f"Tencent/WeChat Channels login flow completed: {result['account_file']}")
@@ -974,7 +1048,7 @@ async def dispatch(args: argparse.Namespace) -> int:
 
     if args.platform == "youtube":
         if args.action == "login":
-            result = await login_youtube_account(args.account, headless=args.headless)
+            result = await login_youtube_account(args.account, headless=args.headless, cdp_url=args.cdp_url)
             if not result["success"]:
                 raise RuntimeError(result["message"])
             print(f"YouTube login flow completed: {result['account_file']}")

--- a/uploader/tencent_uploader/main.py
+++ b/uploader/tencent_uploader/main.py
@@ -70,7 +70,9 @@ def _build_launch_kwargs(headless: bool) -> dict:
     if LOCAL_CHROME_PATH:
         launch_kwargs["executable_path"] = LOCAL_CHROME_PATH
     else:
-        launch_kwargs["channel"] = "chrome"
+        # channel: 默认 chromium (patchright bundled),SAU_BROWSER_CHANNEL 可覆盖回 "chrome"
+        # 原来默认 chrome 要求系统装 Google Chrome,WSL2 / Linux server fail
+        launch_kwargs["channel"] = os.environ.get("SAU_BROWSER_CHANNEL", "chromium").strip() or "chromium"
     return launch_kwargs
 
 
@@ -345,13 +347,21 @@ async def tencent_cookie_gen(
     poll_interval: int = 3,
     max_checks: int = 100,
     headless: bool = LOCAL_CHROME_HEADLESS,
+    cdp_url: str | None = None,
 ):
     account_file = _resolve_account_file(account_file)
     Path(account_file).parent.mkdir(parents=True, exist_ok=True)
 
     async with async_playwright() as playwright:
-        browser = await playwright.chromium.launch(**_build_launch_kwargs(headless=headless))
-        context = await browser.new_context()
+        if cdp_url:
+            # CDP 模式 (WSL2 + Windows Chrome via Python TCP proxy) — 不关 browser
+            browser = await playwright.chromium.connect_over_cdp(cdp_url)
+            context = browser.contexts[0] if browser.contexts else await browser.new_context()
+            should_close_browser = False
+        else:
+            browser = await playwright.chromium.launch(**_build_launch_kwargs(headless=headless))
+            context = await browser.new_context()
+            should_close_browser = True
         qrcode_path = None
         result = _build_login_result(False, "failed", "视频号登录失败", account_file)
         try:
@@ -397,7 +407,8 @@ async def tencent_cookie_gen(
             if not result["success"]:
                 tencent_logger.error(_msg("😢", f"登录失败: {result['message']}"))
             await context.close()
-            await browser.close()
+            if should_close_browser:
+                await browser.close()
 
 
 async def tencent_setup(
@@ -406,6 +417,7 @@ async def tencent_setup(
     return_detail=False,
     qrcode_callback=None,
     headless: bool = LOCAL_CHROME_HEADLESS,
+    cdp_url: str | None = None,
 ):
     account_file = _resolve_account_file(account_file)
     if not os.path.exists(account_file) or not await cookie_auth(account_file):
@@ -414,15 +426,15 @@ async def tencent_setup(
             return result if return_detail else False
 
         tencent_logger.info(_msg("🥹", "cookie 失效了，准备打开浏览器重新登录"))
-        result = await tencent_cookie_gen(account_file, qrcode_callback=qrcode_callback, headless=headless)
+        result = await tencent_cookie_gen(account_file, qrcode_callback=qrcode_callback, headless=headless, cdp_url=cdp_url)
         return result if return_detail else result["success"]
 
     result = _build_login_result(True, "cookie_valid", "cookie有效", account_file)
     return result if return_detail else True
 
 
-async def get_tencent_cookie(account_file, qrcode_callback=None, headless: bool = LOCAL_CHROME_HEADLESS):
-    return await tencent_cookie_gen(account_file, qrcode_callback=qrcode_callback, headless=headless)
+async def get_tencent_cookie(account_file, qrcode_callback=None, headless: bool = LOCAL_CHROME_HEADLESS, cdp_url: str | None = None):
+    return await tencent_cookie_gen(account_file, qrcode_callback=qrcode_callback, headless=headless, cdp_url=cdp_url)
 
 
 async def weixin_setup(

--- a/uploader/xiaohongshu_uploader/main.py
+++ b/uploader/xiaohongshu_uploader/main.py
@@ -202,6 +202,7 @@ async def xiaohongshu_setup(
     return_detail=False,
     qrcode_callback=None,
     headless: bool = LOCAL_CHROME_HEADLESS,
+    cdp_url: str | None = None,
 ):
     if not os.path.exists(account_file) or not await cookie_auth(account_file):
         if not handle:
@@ -212,6 +213,7 @@ async def xiaohongshu_setup(
             account_file,
             qrcode_callback=qrcode_callback,
             headless=headless,
+            cdp_url=cdp_url,
         )
         return result if return_detail else result["success"]
 
@@ -225,6 +227,7 @@ async def xiaohongshu_cookie_gen(
     poll_interval: int = 3,
     max_checks: int = 100,
     headless: bool = LOCAL_CHROME_HEADLESS,
+    cdp_url: str | None = None,
 ):
     if headless:
         xiaohongshu_logger.info(_msg("🖼️", "小红书登录将以无头模式运行，小人会输出终端二维码并保存本地二维码图片"))
@@ -233,8 +236,16 @@ async def xiaohongshu_cookie_gen(
     account_path.parent.mkdir(parents=True, exist_ok=True)
 
     async with async_playwright() as playwright:
-        browser = await playwright.chromium.launch(headless=headless, channel="chromium")
-        context = await browser.new_context()
+        if cdp_url:
+            # 接已开浏览器 (WSL2 + Windows Chrome via Python TCP proxy)
+            # CDP 模式下不要 close browser — 会关掉用户的 Chrome
+            browser = await playwright.chromium.connect_over_cdp(cdp_url)
+            context = browser.contexts[0] if browser.contexts else await browser.new_context()
+            should_close_browser = False
+        else:
+            browser = await playwright.chromium.launch(headless=headless, channel="chromium")
+            context = await browser.new_context()
+            should_close_browser = True
         context = await set_init_script(context)
         qrcode_path = None
         qrcode_info = None
@@ -282,7 +293,8 @@ async def xiaohongshu_cookie_gen(
             if not result["success"]:
                 xiaohongshu_logger.error(_msg("😢", f"登录失败: {result['message']}"))
             await context.close()
-            await browser.close()
+            if should_close_browser:
+                await browser.close()
         return result
 
 

--- a/uploader/youtube_uploader/main.py
+++ b/uploader/youtube_uploader/main.py
@@ -12,6 +12,7 @@ Login is interactive (Google account, no QR code): the browser opens, the user s
 the storage_state is saved. Reuse it afterwards for fully unattended uploads.
 """
 import asyncio
+import os
 from pathlib import Path
 
 from patchright.async_api import Page, Playwright, async_playwright
@@ -32,6 +33,10 @@ STUDIO_URL = "https://studio.youtube.com"
 UPLOAD_URL = "https://www.youtube.com/upload"
 VISIBILITY = {"public": "PUBLIC", "unlisted": "UNLISTED", "private": "PRIVATE"}
 
+# channel: 默认 chromium (patchright bundled),SAU_BROWSER_CHANNEL 可覆盖回 "chrome"
+# 原来默认 chrome 要求系统装 Google Chrome,WSL2 / Linux server fail
+YT_CHANNEL = os.environ.get("SAU_BROWSER_CHANNEL", "chromium").strip() or "chromium"
+
 
 def _msg(emoji: str, text: str) -> str:
     return f"{emoji} {text}"
@@ -50,7 +55,7 @@ def _build_login_result(success, status, message, account_file, current_url=""):
 async def cookie_auth(account_file) -> bool:
     """登录态是否仍有效：带 cookie 打开 Studio，没被踢到 Google 登录页且进入了频道页即有效。"""
     async with async_playwright() as playwright:
-        browser = await playwright.chromium.launch(headless=True, channel="chrome")
+        browser = await playwright.chromium.launch(headless=True, channel=YT_CHANNEL)
         try:
             context = await browser.new_context(storage_state=account_file)
             context = await set_init_script(context)
@@ -67,12 +72,19 @@ async def cookie_auth(account_file) -> bool:
             await browser.close()
 
 
-async def youtube_cookie_gen(account_file, headless: bool = False):
+async def youtube_cookie_gen(account_file, headless: bool = False, cdp_url: str | None = None):
     """交互式登录：开浏览器让用户登录 Google/YouTube，进入频道页后保存 storage_state。"""
     async with async_playwright() as playwright:
-        # 登录必须显形，让用户输账号密码/二步验证
-        browser = await playwright.chromium.launch(headless=False, channel="chrome")
-        context = await browser.new_context()
+        if cdp_url:
+            # CDP 模式 (WSL2 + Windows Chrome via Python TCP proxy) — 不关 browser
+            browser = await playwright.chromium.connect_over_cdp(cdp_url)
+            context = browser.contexts[0] if browser.contexts else await browser.new_context()
+            should_close_browser = False
+        else:
+            # 登录必须显形，让用户输账号密码/二步验证
+            browser = await playwright.chromium.launch(headless=False, channel=YT_CHANNEL)
+            context = await browser.new_context()
+            should_close_browser = True
         context = await set_init_script(context)
         page = await context.new_page()
         await page.goto(STUDIO_URL, wait_until="domcontentloaded")
@@ -89,19 +101,20 @@ async def youtube_cookie_gen(account_file, headless: bool = False):
             youtube_logger.success(_msg("✅", f"YouTube 登录态已保存: {account_file}"))
         else:
             youtube_logger.error(_msg("😵", "等待登录超时，未保存登录态"))
-        await browser.close()
+        if should_close_browser:
+            await browser.close()
         return _build_login_result(ok, "logged_in" if ok else "timeout",
                                    "登录成功" if ok else "登录超时", account_file, page.url)
 
 
-async def youtube_setup(account_file, handle: bool = False, return_detail: bool = False, headless: bool = False):
+async def youtube_setup(account_file, handle: bool = False, return_detail: bool = False, headless: bool = False, cdp_url: str | None = None):
     """校验登录态，失效且 handle=True 时拉起交互式登录。"""
     if not Path(account_file).exists() or not await cookie_auth(account_file):
         if not handle:
             result = _build_login_result(False, "cookie_invalid", "登录态不存在或已失效", account_file)
             return result if return_detail else False
         youtube_logger.info(_msg("🥹", "YouTube 登录态不存在或失效，准备打开浏览器登录"))
-        result = await youtube_cookie_gen(account_file, headless=headless)
+        result = await youtube_cookie_gen(account_file, headless=headless, cdp_url=cdp_url)
         return result if return_detail else result["success"]
     result = _build_login_result(True, "cookie_valid", "登录态有效", account_file)
     return result if return_detail else True
@@ -199,7 +212,7 @@ class YouTubeVideo(BaseVideoUploader):
 
     async def upload(self, playwright: Playwright) -> None:
         browser = await playwright.chromium.launch(
-            headless=self.headless, channel="chrome",
+            headless=self.headless, channel=YT_CHANNEL,
             proxy={"server": YT_PROXY} if YT_PROXY else None,
         )
         context = await browser.new_context(storage_state=self.account_file)


### PR DESCRIPTION
## Problem

WSL2 users running SAU from WSL bash want to use their **desktop Chrome** (already logged into the platform) for scan-QR login instead of letting Playwright launch a fresh bundled Chromium. The mechanism is the Chrome DevTools Protocol (CDP) — Playwright `connect_over_cdp()` attaches to an already-running browser instead of spawning one.

Doublin / Kuaishou already had `--cdp-url` (wired in earlier work). The other three Playwright-based platforms — xiaohongshu, tencent, youtube — were missing it, leaving WSL users on those platforms no choice but to either:

- Use bundled chromium + scan QR through WSLg (broken on most setups: WebGL/IME/render issues), or
- Patch the source to add `cdp_url` themselves.

Bilibili uses biliup CLI (subprocess), so `--cdp-url` is not applicable there.

## Fix

1. **`uploader/xiaohongshu_uploader/main.py`** — add `cdp_url` to `xiaohongshu_setup` and `xiaohongshu_cookie_gen`. Inside `cookie_gen`, when `cdp_url` is set, use `playwright.chromium.connect_over_cdp()` instead of `launch()`, reuse existing context if present. Guard `browser.close()` with `should_close_browser` flag (CDP browser must NOT be closed).

2. **`uploader/tencent_uploader/main.py`** — same pattern for `tencent_setup`, `tencent_cookie_gen`, `get_tencent_cookie`.

3. **`uploader/youtube_uploader/main.py`** — same pattern for `youtube_setup`, `youtube_cookie_gen`.

4. **`sau_cli.py`** — add `cdp_url` parameter to `login_xiaohongshu_account`, `login_tencent_account`, `login_youtube_account`. Add `--cdp-url` argparse to xiaohongshu, tencent, youtube login parsers (mirroring douyin/kuaishou). Wire `cdp_url=args.cdp_url` at dispatch sites.

5. **`docs/WSL-USER-GUIDE.md`** — new file covering the full WSL2 / Linux-server workflow:
   - Why `--headed` is the default for douyin (anti-bot detection)
   - Chrome 111+ IPv6 binding problem + Python IPv4→IPv6 TCP proxy solution
   - WSL2 `.bat` must be ASCII (UTF-8 echo trap in cmd GBK)
   - `--user-data-dir` preservation
   - Complete end-to-end workflow example

## Why `--cdp-url` matters for WSL

A typical WSL2 user setup:
- Desktop Chrome (Windows): logged into all platforms, has UI window
- WSL2 bash: runs SAU CLI
- WSL cannot reach Windows `127.0.0.1` (WSL has its own loopback)
- WSL can reach Windows `172.19.224.1` (vEthernet (WSL) bridge IP)

So WSL users run a Python TCP proxy on Windows that forwards `0.0.0.0:9222` → `[::1]:9222` (Chrome's actual bind address on Windows after Chrome 111+ removed `--remote-debugging-address`). Then SAU attaches via `--cdp-url http://172.19.224.1:9222`.

Without this fix, SAU would launch a new headless Chromium (no UI, can't scan QR) or fail outright if no browser is available.

## Usage

```bash
# Desktop Chrome already running on Windows with --remote-debugging-port=9222
sau xiaohongshu login --account myaccount --headed --cdp-url http://172.19.224.1:9222
sau tencent login --account myaccount --headed --cdp-url http://172.19.224.1:9222
sau youtube login --account myaccount --headed --cdp-url http://172.19.224.1:9222
```

## Testing

- All 4 platforms parse `--cdp-url` correctly:
  ```
  douyin: cdp_url=http://172.19.224.1:9222 ✓
  xiaohongshu: cdp_url=http://172.19.224.1:9222 ✓
  tencent: cdp_url=http://172.19.224.1:9222 ✓
  youtube: cdp_url=http://172.19.224.1:9222 ✓
  ```
- Existing test suite: **31 passed**, 2 deselected (pre-existing failures on main, unrelated to this PR).
- All 3 modified uploader modules import cleanly.

## Affected files

```
 docs/WSL-USER-GUIDE.md                | 219 ++++++++++++++++++++++++++++++++++
 sau_cli.py                            |  99 ++++++++++++---
 uploader/tencent_uploader/main.py     |  22 +++-
 uploader/xiaohongshu_uploader/main.py |  18 ++-
 uploader/youtube_uploader/main.py     |  22 ++--
 5 files changed, 349 insertions(+), 31 deletions(-)
```

## Related

- PR #246 (channel default chromium + `SAU_BROWSER_CHANNEL` override) — the first half of the WSL story.
- [OpenClaw issue #108262](https://github.com/openclaw/openclaw/issues/108262) — unrelated agent fallback bug, but commonly encountered in the same WSL workflow.
