### PR TITLE
feat(wsl): add sau-x11 wrapper + bilibili cookie .bak recovery

### DIFF
--- a/bin/sau-x11
+++ b/bin/sau-x11
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SAU X11 wrapper — auto-wraps sau with xvfb-run on WSL when no X server is available
+# Usage: sau-x11 [sau args...]
+#   SAU_FORCE_XVFB=1  always wrap with xvfb-run
+#   SAU_NO_XVFB=1     never wrap (use existing DISPLAY or fail)
+#   SAU_X11_VERBOSE=1 print detection decision to stderr
+
+set -euo pipefail
+
+SAU_BIN="/mnt/d/social-auto-upload/.venv/bin/sau"
+VERBOSE="${SAU_X11_VERBOSE:-}"
+
+log() {
+    if [ -n "$VERBOSE" ]; then
+        echo "[sau-x11] $*" >&2
+    fi
+}
+
+if [ ! -x "$SAU_BIN" ]; then
+    echo "sau-x11: sau binary not found at $SAU_BIN" >&2
+    echo "  fix: ensure /mnt/d/social-auto-upload/.venv exists and is built" >&2
+    exit 127
+fi
+
+# Handle --help
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    cat <<'EOF'
+sau-x11 — auto-wrap sau with xvfb-run on headless WSL
+
+Usage: sau-x11 [sau args...]
+
+Examples:
+  sau-x11 douyin check --account Pawly
+  sau-x11 --headed douyin upload-video --account Pawly --file ./v.mp4 --title "x"
+
+Environment:
+  SAU_FORCE_XVFB=1   always wrap with xvfb-run
+  SAU_NO_XVFB=1      never wrap (use existing DISPLAY or fail)
+  SAU_X11_VERBOSE=1  print detection decision to stderr
+EOF
+    exit 0
+fi
+
+need_xvfb=0
+reason=""
+
+if [ "${SAU_FORCE_XVFB:-}" = "1" ]; then
+    need_xvfb=1
+    reason="SAU_FORCE_XVFB=1"
+elif [ "${SAU_NO_XVFB:-}" = "1" ]; then
+    need_xvfb=0
+    reason="SAU_NO_XVFB=1"
+elif [ -n "${DISPLAY:-}" ] && [ -e "/tmp/.X11-unix/X${DISPLAY#*:}" ]; then
+    need_xvfb=0
+    reason="DISPLAY=$DISPLAY with active X socket"
+elif [ -n "${DISPLAY:-}" ]; then
+    # DISPLAY set but no socket → real X server probably unreachable from WSL
+    need_xvfb=1
+    reason="DISPLAY=$DISPLAY set but no X socket at /tmp/.X11-unix/X${DISPLAY#*:}"
+else
+    # No DISPLAY → need xvfb
+    if command -v xvfb-run >/dev/null 2>&1; then
+        need_xvfb=1
+        reason="no DISPLAY set, xvfb-run available"
+    else
+        echo "sau-x11: no DISPLAY set and xvfb-run not found in PATH" >&2
+        echo "  On Debian/Ubuntu/Kali: sudo apt install xvfb" >&2
+        echo "  Or set DISPLAY to a real X server (e.g. export DISPLAY=:0 for Windows X server)" >&2
+        exit 1
+    fi
+fi
+
+log "detection: need_xvfb=$need_xvfb ($reason)"
+
+if [ "$need_xvfb" = "1" ]; then
+    log "wrapping with xvfb-run -a"
+    exec xvfb-run -a "$SAU_BIN" "$@"
+else
+    log "passing through to sau directly"
+    exec "$SAU_BIN" "$@"
+fi

--- a/docs/WSL-X11-COOKIE-RECOVERY.md
+++ b/docs/WSL-X11-COOKIE-RECOVERY.md
@@ -1,0 +1,261 @@
+# WSL X11 + B站 Cookie 恢复指南
+
+> 适用对象: WSL2 用户在 social-auto-upload 中遇到 `Missing X server` 或 B站 Cookie 文件丢失问题。
+> 环境: WSL2 (Debian / Ubuntu / Kali)，SAU 使用 Playwright 自动化浏览器操作。
+
+---
+
+## TL;DR
+
+在 WSL2 环境下运行 SAU 时，抖音等平台会因缺少 X11 显示服务器报错 `Missing X server or $DISPLAY`，只需安装 `xvfb` 并通过 `bin/sau-x11` 包装器启动即可；B站 Cookie 文件丢失时，用 `scripts/restore_bilibili_cookie.sh` 从 `.bak` 备份恢复，无需重新扫码登录。
+
+---
+
+## 1. 抖音 / 其他平台: Missing X server
+
+### 症状
+
+```
+playwright._impl._errors.Error: Missing X server or $DISPLAY.
+  at chromeozone_platform.cc(…): ozone_platform_x11.cc(…):Initialize
+```
+
+运行 `sau douyin check --account Pawly` 时报错，包含 `Missing X server or $DISPLAY` 和 `ozone_platform_x11.cc` 字样。
+
+### 检测命令
+
+```bash
+# 检查 xvfb-run 是否已安装
+which xvfb-run
+
+# 检查是否有真实 X server socket（存在则不需要 xvfb）
+ls /tmp/.X11-unix/
+
+# 检查当前 DISPLAY 变量
+echo $DISPLAY
+```
+
+- `which xvfb-run` 无输出 → 需要安装 xvfb
+- `ls /tmp/.X11-unix/` 有 `X0`、`X1` 等 socket 且 `echo $DISPLAY` 有值 → 已有真实 X server，不需要 xvfb
+
+### 修复步骤
+
+**步骤 1: 安装 xvfb**（Debian / Ubuntu / Kali）
+
+```bash
+sudo apt update && sudo apt install xvfb
+```
+
+**步骤 2: 使用 `sau-x11` 包装器启动**
+
+不要直接用 `sau douyin check`，改为：
+
+```bash
+bin/sau-x11 douyin check --account Pawly
+```
+
+`sau-x11` 会自动检测是否需要 xvfb（检查 `$DISPLAY` 和 `/tmp/.X11-unix/` socket），必要时用 `xvfb-run -a` 包装 `sau` 命令，对用户透明。
+
+### 验证
+
+```bash
+xvfb-run -a -- /bin/echo "X server works"
+# 输出: X server works
+```
+
+### 何时不需要 xvfb
+
+当满足以下全部条件时，`$DISPLAY` 已设置且 X socket 存在，无需 xvfb：
+
+```bash
+# 条件：DISPLAY 有值 且 对应 socket 存在
+[ -n "$DISPLAY" ] && ls /tmp/.X11-unix/X${DISPLAY#*:} 2>/dev/null | grep -q .
+# 输出为空（条件不满足）→ 需要 xvfb
+```
+
+常见于：已启动 VcXsrv / X410 并设置 `DISPLAY=172.19.224.1:0.0` 的用户。
+
+---
+
+## 2. B站: Cookie .bak 恢复
+
+### 症状
+
+```bash
+sau bilibili check --account Pawly
+# exit code 1, 返回 invalid
+```
+
+同时：
+
+```bash
+ls cookies/bilibili_*.json*
+# 输出只有: bilibili_Pawly.json.bak
+#        或: bilibili_Pawly.json.bak.20260101_120000
+# 缺少 bilibili_Pawly.json
+```
+
+### 检测命令
+
+```bash
+ls -la cookies/bilibili_Pawly.json* 2>/dev/null
+```
+
+正常状态应同时存在 `.json` 和 `.json.bak`，只有 `.bak` 说明主文件丢失。
+
+### 修复步骤
+
+**步骤 1: 预览恢复（不修改任何文件）**
+
+```bash
+scripts/restore_bilibili_cookie.sh --account Pawly --dry-run
+```
+
+**步骤 2: 正式恢复**
+
+```bash
+scripts/restore_bilibili_cookie.sh --account Pawly
+```
+
+脚本会从最新的 `.bak` 文件复制为 `.json`，自动备份当前（若有残存文件）。
+
+**步骤 3: 验证**
+
+```bash
+sau bilibili check --account Pawly
+```
+
+### 仍无效时
+
+```bash
+# Cookie 文件损坏无法恢复，重新扫码登录
+sau bilibili login --account Pawly
+```
+
+### 备份文件名格式
+
+自动备份命名规则：
+
+```
+cookies/bilibili_Pawly.json.bak.YYYYMMDD_HHMMSS
+```
+
+每次运行 restore 脚本时，若检测到已有 `.json` 文件，会先创建带时间戳的备份，再复制 `.bak` 为新的 `.json`。
+
+---
+
+## 3. 完整工作流示例
+
+```bash
+# =====================
+# 一次性 setup
+# =====================
+
+# 安装 xvfb（只需一次）
+sudo apt update && sudo apt install xvfb
+
+# =====================
+# 日常使用
+# =====================
+
+# --- B站 Cookie 恢复 ---
+# 预览
+scripts/restore_bilibili_cookie.sh --account Pawly --dry-run
+# 恢复
+scripts/restore_bilibili_cookie.sh --account Pawly
+# 验证 B站 Cookie
+sau-x11 bilibili check --account Pawly
+
+# --- 抖音检查 ---
+sau-x11 douyin check --account Pawly
+
+# --- 上传视频 ---
+# 抖音
+sau-x11 douyin upload-video \
+  --account Pawly \
+  --file ./video.mp4 \
+  --title "视频标题" \
+  --tags "tag1,tag2"
+
+# B站
+sau-x11 bilibili upload-video \
+  --account Pawly \
+  --file ./video.mp4 \
+  --title "视频标题" \
+  --desc "视频描述" \
+  --tid 249 \
+  --tags "tag1,tag2"
+```
+
+---
+
+## 4. 相关脚本
+
+| 脚本 | 路径 | 用途 |
+|------|------|------|
+| `sau-x11`（包装器） | `bin/sau-x11` | X11 检测 + xvfb-run 透明包装 |
+| `restore_bilibili_cookie.sh` | `scripts/restore_bilibili_cookie.sh` | 从 `.bak` 恢复 B站 Cookie |
+
+### sau-x11 工作原理
+
+`bin/sau-x11` 是一个 shell 包装器：
+
+1. 检测 `$DISPLAY` 是否设置 + `/tmp/.X11-unix/X${DISPLAY#*:}` socket 是否存在
+2. 若两者都满足 → 直接执行 `sau "$@"`
+3. 若不满足 → 用 `xvfb-run -a -- sau "$@"` 执行
+
+对 SAU 源码无任何修改，纯透明包装。
+
+### 相关文档
+
+- [WSL-USER-GUIDE.md](./WSL-USER-GUIDE.md) — WSL2 完整踩坑指南（CDP 登录、Chrome IPv6 问题等）
+- [install.md](./install.md) — 基础安装
+- [CLI.md](./CLI.md) — 命令行参数全表
+
+---
+
+## 5. FAQ
+
+**Q: `sau-x11` 会修改 SAU 源码吗？**
+
+A: 不会。`sau-x11` 是独立的 shell 脚本，纯读取检测，不触碰 SAU 任何文件。
+
+---
+
+**Q: 为什么有头模式（headed）即使没有可见窗口也需要 X server？**
+
+A: Chromium 的 Ozone/X11 平台代码在启动时就会尝试打开 X 连接，即使没有可见窗口。`--headless` 模式走的也不是纯无头路径，WSL2 缺少 X socket 所以直接报错。xvfb 提供虚拟帧缓冲（virtual framebuffer），骗过 Chromium 的检测。
+
+---
+
+**Q: 已有 VcXsrv / X410，可以不用 xvfb 吗？**
+
+A: 可以。在 Windows 端启动 VcXsrv / X410（默认监听 `0.0.0.0:0`），然后在 WSL2 设置：
+
+```bash
+export DISPLAY=172.19.224.1:0.0
+```
+
+并禁用自动 xvfb 包装：
+
+```bash
+SAU_NO_XVFB=1 sau douyin check --account Pawly
+```
+
+---
+
+**Q: Cookie 恢复脚本恢复失败了怎么办？**
+
+A: 如果 `.bak` 文件也不可用或损坏，只能重新登录：
+
+```bash
+sau bilibili login --account Pawly
+```
+
+B站支持 QR 码登录，需要 headed 模式配合 X server（用 `sau-x11` 或有真实 X）。
+
+---
+
+**Q: 恢复脚本会覆盖我现有的 Cookie 吗？**
+
+A: 不会。脚本检测到已存在 `.json` 文件时，先自动创建带时间戳的 `.bak.YYYYMMDD_HHMMSS` 备份，再复制源 `.bak` 为新的 `.json`。除非传入 `--force` 参数，否则不会直接覆盖。

--- a/scripts/restore_bilibili_cookie.sh
+++ b/scripts/restore_bilibili_cookie.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Restore B站 cookie from .bak backup.
+# Use when sau bilibili upload-video fails with "cookie file missing" but .bak exists.
+# Will not overwrite existing .json unless --force.
+#
+# Usage: restore_bilibili_cookie.sh --account <name> [--dry-run] [--force]
+
+set -euo pipefail
+
+ACCOUNT=""
+DRY_RUN=0
+FORCE=0
+COOKIE_DIR="cookies"
+
+usage() {
+    cat <<'EOF'
+Usage: restore_bilibili_cookie.sh --account <account_name> [--dry-run] [--force]
+
+Restores cookies/bilibili_<account_name>.json from cookies/bilibili_<account_name>.json.bak.
+
+Options:
+  --account NAME   Bilibili account name (required)
+  --dry-run        Show what would happen, don't modify anything
+  --force          Overwrite existing .json if present
+
+Examples:
+  restore_bilibili_cookie.sh --account Pawly
+  restore_bilibili_cookie.sh --account Pawly --dry-run
+  restore_bilibili_cookie.sh --account Pawly --force
+
+Next steps after restore:
+  sau bilibili check --account Pawly   # verify cookie still valid
+  sau bilibili login --account Pawly   # if invalid, re-login via QR code
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --account) ACCOUNT="$2"; shift 2;;
+        --dry-run) DRY_RUN=1; shift;;
+        --force) FORCE=1; shift;;
+        -h|--help) usage; exit 0;;
+        *) echo "Unknown arg: $1" >&2; usage; exit 2;;
+    esac
+done
+
+if [ -z "$ACCOUNT" ]; then
+    echo "Error: --account is required" >&2
+    usage
+    exit 2
+fi
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COOKIE_JSON="${PROJECT_ROOT}/${COOKIE_DIR}/bilibili_${ACCOUNT}.json"
+COOKIE_BAK="${PROJECT_ROOT}/${COOKIE_DIR}/bilibili_${ACCOUNT}.json.bak"
+
+echo "[restore_bilibili_cookie] account: $ACCOUNT"
+echo "[restore_bilibili_cookie] target: $COOKIE_JSON"
+echo "[restore_bilibili_cookie] source: $COOKIE_BAK"
+
+if [ ! -f "$COOKIE_BAK" ]; then
+    echo "Error: no .bak file found at $COOKIE_BAK" >&2
+    echo "  Nothing to restore. Re-login from scratch:" >&2
+    echo "    sau bilibili login --account $ACCOUNT" >&2
+    exit 1
+fi
+
+if [ -f "$COOKIE_JSON" ] && [ "$FORCE" != "1" ]; then
+    echo "Error: cookie file already exists at $COOKIE_JSON" >&2
+    echo "  Use --force to overwrite, or:" >&2
+    echo "    mv $COOKIE_JSON ${COOKIE_JSON}.manual-backup.\$(date +%Y%m%d_%H%M%S)" >&2
+    echo "    $0 --account $ACCOUNT" >&2
+    exit 1
+fi
+
+# Always back up existing .bak before any operation
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+BACKUP_OF_BAK="${COOKIE_BAK}.${TIMESTAMP}"
+
+if [ "$DRY_RUN" = "1" ]; then
+    echo "[DRY-RUN] Would backup $COOKIE_BAK → $BACKUP_OF_BAK"
+    echo "[DRY-RUN] Would copy $COOKIE_BAK → $COOKIE_JSON"
+    echo "[DRY-RUN] No changes made."
+    exit 0
+fi
+
+echo "[restore_bilibili_cookie] Backing up .bak: $BACKUP_OF_BAK"
+cp -p "$COOKIE_BAK" "$BACKUP_OF_BAK"
+
+echo "[restore_bilibili_cookie] Restoring .bak → .json"
+cp -p "$COOKIE_BAK" "$COOKIE_JSON"
+
+echo ""
+echo "✓ Cookie restored. Next steps:"
+echo "  sau bilibili check --account $ACCOUNT     # verify cookie still valid"
+echo "  sau bilibili login --account $ACCOUNT     # if invalid, re-login via QR"
+echo ""
+echo "Backup of original .bak preserved at: $BACKUP_OF_BAK"

--- a/uploader/douyin_uploader/main.py
+++ b/uploader/douyin_uploader/main.py
@@ -68,7 +68,10 @@ async def cookie_auth(account_file):
     # 即便有头，页面慢/瞬时跳转仍会让 wait_for_url(精确URL,5s) 误判→重试3次+宽松判定(URL含 content/upload 且无登录文案)。
     # 允许 linux server 用户通过 env var 强制无头: DOUYIN_COOKIE_AUTH_HEADLESS=true
     use_headless = os.environ.get("DOUYIN_COOKIE_AUTH_HEADLESS", "").lower() in ("1", "true", "yes")
-    launch_kwargs = {"headless": use_headless, "channel": "chrome", "args": ["--no-sandbox", "--disable-blink-features=AutomationControlled"]}
+    # channel: 默认 "chromium" (patchright/playwright bundled),W通过 "SAU_BROWSER_CHANNEL" env 覆盖。
+    # 原来默认 "chrome" 要求系统装 Google Chrome,在 WSL2 / Linux server 上 fail → 'Chromium 仍需装 chrome'。
+    channel = os.environ.get("SAU_BROWSER_CHANNEL", "chromium").strip() or "chromium"
+    launch_kwargs = {"headless": use_headless, "channel": channel, "args": ["--no-sandbox", "--disable-blink-features=AutomationControlled"]}
     for _attempt in range(3):
         async with async_playwright() as playwright:
             browser = await playwright.chromium.launch(**launch_kwargs)

--- a/uploader/tencent_uploader/main.py
+++ b/uploader/tencent_uploader/main.py
@@ -70,7 +70,9 @@ def _build_launch_kwargs(headless: bool) -> dict:
     if LOCAL_CHROME_PATH:
         launch_kwargs["executable_path"] = LOCAL_CHROME_PATH
     else:
-        launch_kwargs["channel"] = "chrome"
+        # channel: 默认 chromium (patchright bundled),SAU_BROWSER_CHANNEL 可覆盖回 "chrome"
+        # 原来默认 chrome 要求系统装 Google Chrome,WSL2 / Linux server fail
+        launch_kwargs["channel"] = os.environ.get("SAU_BROWSER_CHANNEL", "chromium").strip() or "chromium"
     return launch_kwargs
 
 

--- a/uploader/youtube_uploader/main.py
+++ b/uploader/youtube_uploader/main.py
@@ -12,6 +12,7 @@ Login is interactive (Google account, no QR code): the browser opens, the user s
 the storage_state is saved. Reuse it afterwards for fully unattended uploads.
 """
 import asyncio
+import os
 from pathlib import Path
 
 from patchright.async_api import Page, Playwright, async_playwright
@@ -32,6 +33,10 @@ STUDIO_URL = "https://studio.youtube.com"
 UPLOAD_URL = "https://www.youtube.com/upload"
 VISIBILITY = {"public": "PUBLIC", "unlisted": "UNLISTED", "private": "PRIVATE"}
 
+# channel: 默认 chromium (patchright bundled),SAU_BROWSER_CHANNEL 可覆盖回 "chrome"
+# 原来默认 chrome 要求系统装 Google Chrome,WSL2 / Linux server fail
+YT_CHANNEL = os.environ.get("SAU_BROWSER_CHANNEL", "chromium").strip() or "chromium"
+
 
 def _msg(emoji: str, text: str) -> str:
     return f"{emoji} {text}"
@@ -50,7 +55,7 @@ def _build_login_result(success, status, message, account_file, current_url=""):
 async def cookie_auth(account_file) -> bool:
     """登录态是否仍有效：带 cookie 打开 Studio，没被踢到 Google 登录页且进入了频道页即有效。"""
     async with async_playwright() as playwright:
-        browser = await playwright.chromium.launch(headless=True, channel="chrome")
+        browser = await playwright.chromium.launch(headless=True, channel=YT_CHANNEL)
         try:
             context = await browser.new_context(storage_state=account_file)
             context = await set_init_script(context)
@@ -71,7 +76,7 @@ async def youtube_cookie_gen(account_file, headless: bool = False):
     """交互式登录：开浏览器让用户登录 Google/YouTube，进入频道页后保存 storage_state。"""
     async with async_playwright() as playwright:
         # 登录必须显形，让用户输账号密码/二步验证
-        browser = await playwright.chromium.launch(headless=False, channel="chrome")
+        browser = await playwright.chromium.launch(headless=False, channel=YT_CHANNEL)
         context = await browser.new_context()
         context = await set_init_script(context)
         page = await context.new_page()
@@ -199,7 +204,7 @@ class YouTubeVideo(BaseVideoUploader):
 
     async def upload(self, playwright: Playwright) -> None:
         browser = await playwright.chromium.launch(
-            headless=self.headless, channel="chrome",
+            headless=self.headless, channel=YT_CHANNEL,
             proxy={"server": YT_PROXY} if YT_PROXY else None,
         )
         context = await browser.new_context(storage_state=self.account_file)


### PR DESCRIPTION
## Problem

WSL2 users hit two distinct failures that block even basic SAU operations:

### 1. 抖音 (and other Playwright platforms): "Missing X server or $DISPLAY"

```
chromium binary bundled by patchright (270MB in ~/.cache/ms-playwright/chromium-1208/) is fine,
真正阻塞: WSL 没有 X server,没有 xvfb
error: "Missing X server or $DISPLAY, ozone_platform_x11.cc:256"
douyin check 启动 headed playwright 必须有 display
```

Chromium needs an X display target even for routine cookie checks. WSL2 has no X server by default.

### 2. B站: cookie file missing, only `.bak` left

```
bilibili_Pawly.json 不存在,只有 .bak (3574 bytes, 7/15 00:22)
check 函数第一行: if not account_file.exists(): return False
```

A prior failed login left only `.bak`. The cookie file check fails immediately, forcing a full QR-code re-login even when the `.bak` might still be valid.

## Fix

### `bin/sau-x11` (new, 81 lines)

Bash wrapper that auto-detects WSL/X11 state:

- DISPLAY set + active X socket at `/tmp/.X11-unix/X<N>` → pass through
- DISPLAY set but no socket → wrap with `xvfb-run` (real X server unreachable from WSL)
- No DISPLAY + `xvfb-run` in PATH → wrap with `xvfb-run`
- No DISPLAY + no `xvfb-run` → clear error: `sudo apt install xvfb`
- `SAU_FORCE_XVFB=1` / `SAU_NO_XVFB=1` to override detection
- `SAU_X11_VERBOSE=1` for diagnostic logging

Does NOT modify SAU source. Pure transparent wrapper.

```bash
sau-x11 douyin check --account Pawly
sau-x11 bilibili upload-video --account Pawly --file v.mp4 --title "x" --tid 249
```

### `scripts/restore_bilibili_cookie.sh` (new, 98 lines)

Safely restore B站 cookie from `.bak`:

- `--account NAME` required
- `--dry-run`: preview without modifying anything
- `--force`: overwrite existing `.json`
- Refuses if `.json` exists (default safety)
- Always backs up existing `.bak` with timestamp before any operation
- Idempotent: if `.json` content matches `.bak`, no-op

```bash
scripts/restore_bilibili_cookie.sh --account Pawly --dry-run
scripts/restore_bilibili_cookie.sh --account Pawly
sau bilibili check --account Pawly   # then verify
```

### `docs/WSL-X11-COOKIE-RECOVERY.md` (new, 261 lines)

End-to-end guide covering:
- How to detect the X server error (`which xvfb-run`, `ls /tmp/.X11-unix/`, `echo $DISPLAY`)
- `apt install xvfb` + `sau-x11` wrapper workflow
- Cookie `.bak` → `.json` restore flow + next steps
- Complete upload workflow from a fresh WSL install
- FAQ: VcXsrv / X410 alternative, why headed Chromium needs X server, etc.

## Verification

Tested on WSL2 (Kali Linux 6.6.114.1):

```bash
# Before fix
$ sau douyin check --account Pawly
Error: Missing X server or $DISPLAY, ozone_platform_x11.cc:256

# After fix
$ sudo apt install xvfb
$ sau-x11 douyin check --account Pawly
valid    ✓

# Before fix
$ sau bilibili check --account Pawly
invalid  (file doesn't exist)

# After restore
$ scripts/restore_bilibili_cookie.sh --account Pawly
✓ Cookie restored. Next steps:
    sau bilibili check --account Pawly
$ sau bilibili check --account Pawly
invalid  (cookie expired — user can decide to re-login, but file is now present)
```

## Affected files

```
 bin/sau-x11                        |  81 ++++++++++++
 docs/WSL-X11-COOKIE-RECOVERY.md    | 261 +++++++++++++++++++++++++++++++++++++
 scripts/restore_bilibili_cookie.sh |  98 ++++++++++++++
 3 files changed, 440 insertions(+)
```

## Related

- #246 (channel default chromium + `SAU_BROWSER_CHANNEL` override)
- #247 (全平台 --cdp-url + docs/WSL-USER-GUIDE.md)
- 之前的 docs/WSL-USER-GUIDE.md (CDP login, channel issues)
