### PR TITLE
test(upload): regression tests for path traversal fix in upload endpoints

### DIFF
--- a/tests/test_upload_traversal.py
+++ b/tests/test_upload_traversal.py
@@ -1,0 +1,41 @@
+import io, sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+from sau_backend import app
+import sau_backend
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    (tmp_path / "videoFile").mkdir()
+    monkeypatch.setattr(sau_backend, "BASE_DIR", tmp_path)
+    app.config['TESTING'] = True
+    with app.test_client() as c:
+        yield c, tmp_path
+
+def test_upload_rejects_traversal(client):
+    c, base = client
+    data = {'file': (io.BytesIO(b'x'), '../../evil.mp4')}
+    r = c.post('/upload', data=data, content_type='multipart/form-data')
+    assert r.status_code == 200
+    saved = r.get_json()['data']
+    assert '..' not in saved and '/' not in saved
+    assert (base / 'videoFile' / saved).exists()
+
+def test_upload_normal(client):
+    c, _ = client
+    data = {'file': (io.BytesIO(b'hello'), 'video.mp4')}
+    r = c.post('/upload', data=data, content_type='multipart/form-data')
+    assert r.status_code == 200
+    assert r.get_json()['data'].endswith('_video.mp4')
+
+def test_uploadsave_rejects_empty_after_sanitize(client):
+    c, _ = client
+    data = {'file': (io.BytesIO(b'x'), '../../../')}
+    r = c.post('/uploadSave', data=data, content_type='multipart/form-data')
+    assert r.status_code == 400
+
+def test_getfile_blocks_traversal(client):
+    c, _ = client
+    r = c.get('/getFile?filename=../../etc/passwd')
+    assert r.status_code == 400


### PR DESCRIPTION
## Regression tests for path traversal in upload endpoints

This PR adds a small pytest module (`tests/test_upload_traversal.py`) that pins down the path-traversal hardening applied to `sau_backend.py` in #212 (commit `d8c95b0`). No production code is changed — the diff is 41 lines of tests only.

### Background

`sau_backend.py` exposes three file-handling endpoints on the Flask app that ships as the backend:

- `POST /upload` — saves an uploaded file to `BASE_DIR/videoFile/`
- `POST /uploadSave` — same, plus a DB record and optional `custom_filename`
- `GET  /getFile?filename=…` — serves files back from `BASE_DIR/videoFile/`

Historically these endpoints concatenated the client-supplied filename directly into the destination path. A request like:

```bash
curl -F 'file=@payload;filename=../../evil.sh' http://127.0.0.1:5409/upload
curl 'http://127.0.0.1:5409/getFile?filename=../../etc/passwd'
```

…would let any caller on the network escape the `videoFile/` directory (write on `/upload`, read on `/getFile`). This is CWE-22 (Path Traversal). The Flask app binds `0.0.0.0` with no authentication, so any host that can reach TCP/5409 is a valid attacker under the current threat model.

The fix in #212 addressed this by:

- routing every incoming filename through `werkzeug.utils.secure_filename` on `/upload` and `/uploadSave`,
- rejecting empty results (e.g. inputs like `../../../` that `secure_filename` collapses to `""`) with HTTP 400,
- rejecting `..` and leading `/` on the `/getFile?filename=` parameter before it reaches `send_from_directory`.

### What this PR adds

Four focused tests that lock in the above behaviour so it doesn't silently regress if someone later refactors the upload path:

1. `test_upload_rejects_traversal` — posts `filename=../../evil.mp4`, asserts the saved name contains no `..` or `/` and lives under `videoFile/`.
2. `test_upload_normal` — sanity check that a legitimate `video.mp4` upload still succeeds and the saved name ends with `_video.mp4`.
3. `test_uploadsave_rejects_empty_after_sanitize` — posts `filename=../../../` (which `secure_filename` reduces to `""`) and asserts HTTP 400 rather than a silent write with an empty name.
4. `test_getfile_blocks_traversal` — `GET /getFile?filename=../../etc/passwd` must return 400, not stream the file.

The fixture monkeypatches `sau_backend.BASE_DIR` to a `tmp_path`, so the tests are hermetic — they never touch the real `videoFile/` directory or the SQLite DB in the repo.

### Running the tests

```bash
pip install -r requirements.txt        # pulls flask, werkzeug, xhs, etc.
pytest tests/test_upload_traversal.py -v
```

All four tests pass locally against current `main`. (Note: the test module imports `sau_backend`, which transitively imports `xhs` and the other platform SDKs — so the backend's own dependencies must be installed, same as for the existing `tests/test_bilibili_runtime.py` etc.)

### Security analysis

The underlying vulnerability class is straightforward CWE-22: user-controlled filename flowed into a filesystem path (`Path(BASE_DIR / "videoFile" / filename)` and `send_from_directory(dir, filename)`). Impact on the pre-fix code:

- **Write primitive** via `/upload` and `/uploadSave` — an attacker could place a file anywhere the backend process has write access (e.g. overwriting `~/.ssh/authorized_keys`, dropping a `.py` next to the backend to be picked up on restart, replacing scheduler scripts).
- **Read primitive** via `/getFile` — arbitrary file disclosure limited only by the backend user's read permissions.

Both are meaningfully worse than the "attacker can upload a video into `videoFile/`" baseline that other unauthenticated endpoints already grant, because they break out of the intended directory.

### Adversarial review

Before submitting, I tried to argue this test PR wasn't worth landing: the fix is already merged, and the app has other unauthenticated endpoints (cookie upload, video upload) that give a network attacker plenty of reach on their own. But the traversal primitive is a distinct escalation — arbitrary-path write/read is qualitatively different from "write into the app's own upload dir" — and the sanitization logic is easy to inadvertently undo in a future refactor (e.g. someone adding a "preserve original filename" option). A 41-line regression test module is cheap insurance against that. The tests are hermetic, don't add new production dependencies, and only exercise public HTTP behaviour, so they should be low-maintenance.

Happy to adjust naming, split into per-endpoint files, or gate behind a marker if that fits the project's testing conventions better.