### PR TITLE
docs: fix broken stargazer chart by migrating to star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,4 +320,4 @@ sau youtube upload-video --account <account_name> --file videos/demo.mp4 --title
 
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=dreammis/social-auto-upload&type=Date)](https://star-history.com/#dreammis/social-auto-upload&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=dreammis/social-auto-upload&type=Date)](https://star-history.dera.page/#dreammis/social-auto-upload&Date)


### PR DESCRIPTION
The current star history chart in the README was broken because it relied on the GitHub stargazer API (api.star-history.com) which has been restricted.

This PR switches the chart and links to `star-history.dera.page` — a token-less fork of star-history that serves both the SVG and the frontend from the same domain, so `/svg` endpoints keep working.

See https://github.com/Mubelotix/star-history for the alternative data source used.